### PR TITLE
Torchops

### DIFF
--- a/storch/torchops.py
+++ b/storch/torchops.py
@@ -156,18 +156,20 @@ def shuffle_batch(batch: torch.Tensor, return_permutation: bool=False):
     return shuffled
 
 
-def grad_nan_to_num(module: nn.Module, nan: float=0.0, posinf: float=1e5, neginf: float=1e-5):
+def grad_nan_to_num(input: nn.Module|list[torch.Tensor], nan: float=0.0, posinf: float=1e5, neginf: float=1e-5):
     '''set nan gardients to a number.
 
     Arguments:
-        module: nn.Module
-            The module with parameters holding .grad attribute.
+        input: nn.Module|list[torch.Tensor]
+            Module or list of tensors with .grad attribute.
         nan: float (default: 0)
             Value to replace nan.
         posinf, neginf: float (default: 1e5, 1e-5)
             Value to replace positive/negative inf.
     '''
-    params = [param for param in module.parameters() if param.grad is not None]
+    if isinstance(input, nn.Module):
+        input = input.parameters()
+    params = [param for param in input if param.grad is not None]
     if len(params):
         flat = torch.cat([param.grad.flatten() for param in params])
         flat = torch.nan_to_num(flat, nan, posinf, neginf)

--- a/storch/torchops.py
+++ b/storch/torchops.py
@@ -171,13 +171,16 @@ def grad_nan_to_num_(input: nn.Module|list[torch.Tensor], nan: float=0.0, posinf
     if isinstance(input, nn.Module):
         input = input.parameters()
     params = [param for param in input if param.grad is not None]
-    if len(params):
-        flat = torch.cat([param.grad.flatten() for param in params])
-        flat = torch.nan_to_num(flat, nan, posinf, neginf)
-        grads = flat.split([param.numel() for param in params])
-        for param, grad in zip(params, grads):
-            param.grad = grad.reshape(param.shape)
+    for param in params:
+        param.grad = torch.nan_to_num(param.grad, nan, posinf, neginf)
 
+    '''from: https://github.com/NVlabs/stylegan3/blob/1c6608208cb51b7773da32f40ee2232f684c3a21/training/training_loop.py#L283-L292'''
+    # if len(params):
+    #     flat = torch.cat([param.grad.flatten() for param in params])
+    #     flat = torch.nan_to_num(flat, nan, posinf, neginf)
+    #     grads = flat.split([param.numel() for param in params])
+    #     for param, grad in zip(params, grads):
+    #         param.grad = grad.reshape(param.shape)
 
 def optimizer_step(
     loss: torch.Tensor, optimizer: optim.Optimizer, scaler=None,

--- a/storch/torchops.py
+++ b/storch/torchops.py
@@ -156,8 +156,9 @@ def shuffle_batch(batch: torch.Tensor, return_permutation: bool=False):
     return shuffled
 
 
-def grad_nan_to_num(input: nn.Module|list[torch.Tensor], nan: float=0.0, posinf: float=1e5, neginf: float=1e-5):
+def grad_nan_to_num_(input: nn.Module|list[torch.Tensor], nan: float=0.0, posinf: float=1e5, neginf: float=1e-5):
     '''set nan gardients to a number.
+    This is an inplace operation.
 
     Arguments:
         input: nn.Module|list[torch.Tensor]


### PR DESCRIPTION
# WHAT
- Add `clip_grad_norm` and `max_norm` option to `torchops.optimizer_step()`.
- Add `grad_nan_to_num` option to `torchops.optimizer_step()`.
- Support list of tensors input for `torchops.grad_nan_to_num()`.
- Change `torchops.grad_nan_to_num()` function name to `torchops.grad_nan_to_num_()`, so that we know it's an in-place operation.
- Optimize `torchops.grad_nan_to_num_()`.
    - Doesn't change much when using GPU.
    - About 0.01 ~ 0.02 seconds faster on CPU.