### PR TITLE
Utilities for distributed training

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,31 +1,40 @@
-version: '2.3'
-
 services:
   python:
     build:
       context: .
-      dockerfile: docker/torch/Dockerfile
+      dockerfile: ./docker/torch/Dockerfile
       args:
         - UID=${USERID:-1000}
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+
     volumes:
       - .:/usr/src
-    working_dir: /usr/src
-    tty: true
     shm_size: '8gb'
+    working_dir: /usr/src
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              device_ids: ['0']
 
   install:
     build:
       context: .
-      dockerfile: docker/install/Dockerfile
+      dockerfile: ./docker/install/Dockerfile
       args:
         - UID=${USERID:-1000}
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+
     volumes:
       - .:/usr/src
+    shm_size: '8gb'
     working_dir: /usr/src
-    entrypoint: bash ./docker/install/entrypoint.sh
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              device_ids: ['0']

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.12.1-cuda11.3-cudnn8-devel
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
 
 ENV DEBIAN_FRONTEND=noniteractive
 RUN apt update -y && \

--- a/docker/torch/Dockerfile
+++ b/docker/torch/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.12.1-cuda11.3-cudnn8-devel
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
 
 ENV DEBIAN_FRONTEND=noniteractive
 RUN apt update -y && \

--- a/storch/dist_helper.py
+++ b/storch/dist_helper.py
@@ -6,11 +6,13 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
+from stutil.exceptions import deprecated
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import Dataset
 from torch.utils.data.distributed import DistributedSampler
 
 
+@deprecated(favor_of='storch.distributed.DistributedHelper', recommendation='storch.distributed.DistributedHelper')
 class DistributedHelper:
     """Helper class for distributed training.
 

--- a/storch/distributed/__init__.py
+++ b/storch/distributed/__init__.py
@@ -1,0 +1,1 @@
+from storch.distributed.helper import DistributedHelper

--- a/storch/distributed/factory/__init__.py
+++ b/storch/distributed/factory/__init__.py
@@ -1,0 +1,3 @@
+from storch.distributed.factory.ddp import DistributedDataParallelFactory
+from storch.distributed.factory.fsdp import FullyShardedDataParallelFactory
+from storch.distributed.factory.nodp import NoParallelFactory

--- a/storch/distributed/factory/_base.py
+++ b/storch/distributed/factory/_base.py
@@ -1,0 +1,48 @@
+"""Base container classes for data parallel wrapped modules.
+"""
+
+from collections import OrderedDict
+
+import torch.nn as nn
+from torch.optim.optimizer import Optimizer
+
+
+class CheckpointInterfaceBase:
+    """Interface for get/set state_dict from a module.
+    This class is for enabling checkpointing models without any code changes between
+    different parallelization methods (DDP or FSDP).
+
+    inherited classes should work as follows:
+    >>> module = {FSDP,DDP}(original_module, ...)
+    >>> ckpt_if = CheckpointInterface(module, ...)
+    >>> state_dict = ckpt_if.state_dict()
+    >>> if primary_process:
+    ...     torch.save(state_dict, './state_dict')
+    >>> state_dict = torch.load('./state_dict')
+    >>> ckpt_if.load_state_dict(state_dict)
+    """
+    def __init__(self, to_checkpoint: nn.Module|Optimizer) -> None:
+        self.to_checkpoint = to_checkpoint
+
+    def state_dict(self):
+        return self.to_checkpoint.state_dict()
+
+    def load_state_dict(self, state_dict: OrderedDict):
+        self.to_checkpoint.load_state_dict(state_dict)
+
+
+class ParallelFactoryBase:
+    """this class is a factory for wrapped modules.
+    """
+    def __init__(self) -> None:
+        self._wrapped_module = None
+
+    @property
+    def is_wrapped(self) -> None:
+        return self._wrapped_module is not None
+
+    def wrap_module(self, module: nn.Module, **kwargs):
+        raise NotImplementedError
+
+    def create_checkpoint_interface(self, optim, **kwargs):
+        raise NotImplementedError

--- a/storch/distributed/factory/ddp.py
+++ b/storch/distributed/factory/ddp.py
@@ -1,0 +1,31 @@
+"""container for DDP modules"""
+
+from collections import OrderedDict
+
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from storch.distributed.factory._base import (CheckpointInterfaceBase,
+                                              ParallelFactoryBase)
+
+
+class DDPModuleCheckpointInterface(CheckpointInterfaceBase):
+
+    def state_dict(self):
+        return self.to_checkpoint.module.state_dict()
+
+    def load_state_dict(self, state_dict: OrderedDict):
+        self.to_checkpoint.module.load_state_dict(state_dict)
+
+
+class DistributedDataParallelFactory(ParallelFactoryBase):
+
+    def wrap_module(self, module: nn.Module, device_ids: list=None, **kwargs):
+        wrapped_module = DDP(module, device_ids=device_ids)
+        self._wrapped_module = wrapped_module
+        return wrapped_module
+
+    def create_checkpoint_interface(self, optim, **kwargs):
+        assert self.is_wrapped, f'Call "wrap_module()" first.'
+        module_interface = DDPModuleCheckpointInterface(self._wrapped_module)
+        return module_interface, optim

--- a/storch/distributed/factory/fsdp.py
+++ b/storch/distributed/factory/fsdp.py
@@ -1,0 +1,80 @@
+"""container for FSDP modules"""
+
+from __future__ import annotations
+
+from typing import OrderedDict
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import FullStateDictConfig
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, StateDictType
+from torch.optim.optimizer import Optimizer
+
+import storch
+from storch.distributed.factory._base import (CheckpointInterfaceBase,
+                                              ParallelFactoryBase)
+from storch.utils.version import is_torch_version_geq
+
+
+class FSDPModuleCheckpointInterface(CheckpointInterfaceBase):
+    def __init__(self, module: nn.Module, state: dict) -> None:
+        super().__init__(module)
+        self.state = state
+
+    def state_dict(self):
+        if is_torch_version_geq('1.13.5'): # from huggingface/accelerator
+            FSDP.set_state_dict_type(self.to_checkpoint, self.state.type, self.state.config)
+            state_dict = self.to_checkpoint.state_dict()
+        else:
+            with FSDP.state_dict_type(self.to_checkpoint, self.state.type, self.state.config):
+                state_dict = self.to_checkpoint.state_dict()
+        return state_dict
+
+    def load_state_dict(self, state_dict: OrderedDict):
+        if is_torch_version_geq('1.13.5'):
+            FSDP.set_state_dict_type(self.to_checkpoint, self.state.type, self.state.config)
+            self.to_checkpoint.load_state_dict(state_dict)
+        else:
+            with FSDP.state_dict_type(self.to_checkpoint, self.state.type, self.state.config):
+                self.to_checkpoint.load_state_dict(state_dict)
+
+
+class FSDPOptimizerCheckpointInterface(CheckpointInterfaceBase):
+    def __init__(self, optimizer: Optimizer, module: nn.Module) -> None:
+        super().__init__(optimizer)
+        self.module = module
+
+    def state_dict(self):
+        state_dict = FSDP.full_optim_state_dict(self.module, self.to_checkpoint)
+        return state_dict
+
+    def load_state_dict(self, state_dict: OrderedDict):
+        sharded_sd = FSDP.scatter_full_optim_state_dict(state_dict, self.module)
+        self.to_checkpoint.load_state_dict(sharded_sd)
+
+
+class FullyShardedDataParallelFactory(ParallelFactoryBase):
+
+    def wrap_module(self, module: nn.Module, mixed_precision: bool|str, **kwargs):
+        if mixed_precision:
+            dtype = torch.float16
+            mixed_precision = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
+        else: mixed_precision = None
+
+        wrapped_module = FSDP(module, mixed_precision=mixed_precision)
+        self._wrapped_module = wrapped_module
+
+        return wrapped_module
+
+    def create_checkpoint_interface(self, optim, offload_to_cpu: bool, **kwargs):
+        assert self.is_wrapped, f'Call "wrap_module()" first.'
+
+        state = storch.EasyDict()
+        state.type = StateDictType.FULL_STATE_DICT
+        state.config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=offload_to_cpu)
+
+        mci = FSDPModuleCheckpointInterface(self._wrapped_module, state)
+        oci = FSDPOptimizerCheckpointInterface(optim, self._wrapped_module)
+
+        return mci, oci

--- a/storch/distributed/factory/nodp.py
+++ b/storch/distributed/factory/nodp.py
@@ -1,0 +1,16 @@
+"""container without wrapping. for single GPU."""
+
+import torch.nn as nn
+
+from storch.distributed.factory._base import ParallelFactoryBase
+
+
+class NoParallelFactory(ParallelFactoryBase):
+
+    def wrap_module(self, module: nn.Module, **kwargs):
+        self._wrapped_module = module
+        return module
+
+    def create_checkpoint_interface(self, optim, **kwargs):
+        assert self.is_wrapped, f'Call "wrap_module()" first.'
+        return self._wrapped_module, optim

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -169,7 +169,8 @@ class DistributedHelper:
     def wait_for_all_processes():
         """torch.distributed.barrier with a recognizable name.
         """
-        dist.barrier()
+        if dist.is_initialized():
+            dist.barrier()
 
 
     def prepare_module(self, *modules: nn.Module, mode: str=None, mixed_precision: bool=False) -> tuple[nn.Module]|nn.Module:

--- a/storch/status.py
+++ b/storch/status.py
@@ -641,7 +641,7 @@ class ThinStatus:
         self.batches_done = state_dict['batches_done']
 
     def state_dict(self) -> dict:
-        raise NotImplementedError()
+        return {}
 
     def plot(self, filename='loss'):
         pass

--- a/storch/status.py
+++ b/storch/status.py
@@ -554,45 +554,63 @@ class ThinStatus:
     def batches_done(self, value):
         self._batches_done = value
 
-    def print(self, *args, **kwargs):
-        '''print function'''
-        print(*args, **kwargs)
+    def get_kbatches(self, format='{kbatches:.2f}k') -> str:
+        """Returns a formated kilo batches.
 
-    def log(self, message: str, level: str='info'):
-        self.print(message)
+        Args:
+            format (str, optional): format of the string. Default: '{kbatches:.2f}k'.
 
-    def log_command_line(self):
+        Returns:
+            str: The formated kilo batches.
+        """
+        kbatches = self._batches_done / 1000
+        return format.format(kbatches=kbatches)
+
+    def print(self, *args, **kwargs) -> None:
         pass
 
-    def log_args(self, args: Namespace, parser: ArgumentParser=None, filename: str=None):
+    def log(self, message: str, level='info') -> None:
         pass
 
-    def log_omegaconf(self, config: DictConfig):
+    def log_command_line(self) -> None:
         pass
 
-    def log_dataset(self, dataloader: DataLoader):
+    def log_args(self, args: Namespace, parser: ArgumentParser=None, filename: str=None) -> None:
         pass
 
-    def log_optimizer(self, optimizer: Optimizer):
+    def log_omegaconf(self, config: DictConfig) -> None:
         pass
 
-    def log_env(self):
+    def log_dataset(self, dataloader: DataLoader) -> None:
         pass
 
-    def log_model(self, model):
+    def log_optimizer(self, optimizer: Optimizer) -> None:
         pass
 
-    def log_gpu_memory(self):
+    def log_env(self) -> None:
         pass
 
-    def log_nvidia_smi(self):
+    def log_model(self, model: torch.nn.Module) -> None:
         pass
 
-    def log_stuff(self, *args):
+    def log_gpu_memory(self) -> None:
         pass
 
-    def update(self, **kwargs):
+    def log_nvidia_smi(self) -> None:
+        pass
+
+    def log_stuff(self, *to_log) -> None:
+        pass
+
+    def update(self, **kwargs) -> None:
+        """update status."""
         self._batches_done += 1
+
+    def tb_add_scalars(self, **kwargs) -> None:
+        pass
+
+    def tb_add_images(self, tag: str, image_tensor: torch.Tensor, normalize=True, value_range=(-1, 1), nrow=8, **mkgridkwargs) -> None:
+        pass
 
     def initialize_collector(self, *keys):
         pass
@@ -600,15 +618,23 @@ class ThinStatus:
     def update_collector(self, **kwargs):
         pass
 
-    def tb_add_scalars(self, **kwargs):
+    def dry_update(self, **kwargs):
         pass
 
     @contextmanager
-    def stop_timer(self, verbose=False):
+    def profile(self, enabled=True):
         yield
 
-    def is_end(self):
+
+    @contextmanager
+    def stop_timer(self, verbose=False) -> None:
+        yield
+
+    def is_end(self) -> None:
         return self.batches_done >= self.max_iters
+
+    def _shutdown_logger(self) -> None:
+        pass
 
     def load_state_dict(self, state_dict: dict) -> None:
         # load batches_done from the state_dict saved at the primary process.


### PR DESCRIPTION
# WHAT
- Renew utilities for distributed training.

# Changes
- Deprecate `dist_helper.DistributedHelper`.
- Add `distributed`
- Add `distributed.DistributedHelper`.
- Support distributed training in `checkpoint.Checkpoint`.
- Support distributed training in `metrics.best_model.BestStateKeeper`.
  - It now keeps the model state by serializing the model weights instead of keeping a deepcopy on the memory.
- Support distributed training in `torchops.optimizer_step`.
- Support distributed training in `torchops.optimizer_step_with_gradient_accumulation`.

# Breaking changes
## `torchops.optimizer_step`, `torchops.optimizer_step_with_gradient_accumulation`
- To support distributed training, these functions now require inputting the module when the `clip_grad_norm` option is `True`.

## `metrics.best_model.BestStateKeeper`
- To support distributed training, this class now requires the `name` option used to save the model.

# Fix
- Implement missing functions in `status.ThinStatus`.

# Notes
- Currently does not support (not tested to be more precise) multi-node environment.