### PR TITLE
🐛 `torch.compile`

### DIFF
--- a/storch/distributed/factory/fsdp.py
+++ b/storch/distributed/factory/fsdp.py
@@ -62,7 +62,7 @@ class FullyShardedDataParallelFactory(ParallelFactoryBase):
             mixed_precision = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
         else: mixed_precision = None
 
-        wrapped_module = FSDP(module, mixed_precision=mixed_precision)
+        wrapped_module = FSDP(module, mixed_precision=mixed_precision, **kwargs)
         self._wrapped_module = wrapped_module
 
         return wrapped_module

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -219,6 +219,8 @@ class DistributedHelper:
                 elif mode == 'fsdp':
                     factory = FullyShardedDataParallelFactory()
                     wrap_kwargs['mixed_precision'] = mixed_precision
+                    if compile is not None:
+                        wrap_kwargs['use_orig_params'] = True
                 else:
                     raise Exception(f'Unknown data parallelizm mode "{mode}"')
 

--- a/storch/utils/version.py
+++ b/storch/utils/version.py
@@ -38,4 +38,4 @@ def is_multi_weight_api_available():
 
 
 def is_compiler_available():
-    return is_torchvision_version_geq('2.0.0')
+    return is_torch_version_geq('2.0.0')


### PR DESCRIPTION
# WHAT
- `utils.version.is_compiler_available` never returns `True`.
- `torch.compile` fails when the model parallelism mode is FSDP.

# Changes
- Fix `utils.version.is_compiler_available` to check the right module's version.
- Pass `use_orig_version=True` when using FSDP and `torch.compile`.