### PR TITLE
Bugfix

### DIFF
--- a/storch/distributed/factory/fsdp.py
+++ b/storch/distributed/factory/fsdp.py
@@ -75,6 +75,6 @@ class FullyShardedDataParallelFactory(ParallelFactoryBase):
         state.config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=offload_to_cpu)
 
         mci = FSDPModuleCheckpointInterface(self._wrapped_module, state)
-        oci = FSDPOptimizerCheckpointInterface(optim, self._wrapped_module)
+        oci = optim if optim is None else FSDPOptimizerCheckpointInterface(optim, self._wrapped_module)
 
         return mci, oci

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -314,6 +314,8 @@ class DistributedHelper:
         Tested to work well with storch.checkpoint.Checkpoint
 
         Args:
+            *optimizers: The optimizers used from training. If multiple models are used, the optimizers must be passed in the same order.
+                If a model is not intended to be trained, pass None.
             offload_to_cpu (bool, optional): When the model is FSDP, configures is the weights are offload to cpu before serialization.
                 When `True`, it also enables `rank0_only`, which will result in returning empty dicts on processes that are `rank!=0`.
                 Default: True.


### PR DESCRIPTION
# WHAT
- fix #77

# Changes
- Support None as input to `distributed.DistributedHelper.prepare_for_checkpointing`