### PR TITLE
Pass drop_last to DataLoader

### DIFF
--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -294,7 +294,7 @@ class DistributedHelper:
                 shuffle=shuffle, drop_last=drop_last
             )
             dataloader = DataLoader(dataset,
-                batch_size=batch_size, sampler=sampler,
+                batch_size=batch_size, sampler=sampler, drop_last=drop_last,
                 num_workers=num_workers, pin_memory=pin_memory,
                 worker_init_fn=worker_init_fn, generator=generator
             )


### PR DESCRIPTION
# WHAT
- fix #80 
- Pass `drop_last` argument to DataLoader in `distributed.DistributedHelper.prepare_dataset`.