### PR TITLE
✨ hook for GPU memory summary.

### DIFF
--- a/storch/_optimizer_step.py
+++ b/storch/_optimizer_step.py
@@ -40,7 +40,9 @@ def get_optimizer_step(
     gradient_accumulation_steps: int=1,
     num_iters_per_epoch: int=None,
     no_sync_context: Callable=None,
-    module: nn.Module=None
+    module: nn.Module=None,
+    post_backward_hooks: list[Callable]=[],
+    post_optim_step_hooks: list[Callable]=[]
 ):
 
     if module is not None and no_sync_context is None:
@@ -51,6 +53,13 @@ def get_optimizer_step(
         num_iters_per_epoch,
         no_sync_context
     )
+
+    if len(post_backward_hooks) > 0:
+        assert all(callable(hook) for hook in post_backward_hooks), f'all hooks must be callable.'
+        func.register_hooks('backward', *post_backward_hooks)
+    if len(post_optim_step_hooks) > 0:
+        assert all(callable(hook) for hook in post_optim_step_hooks), f'all hooks must be callable.'
+        func.register_hooks('step', *post_optim_step_hooks)
 
     return func
 

--- a/storch/status.py
+++ b/storch/status.py
@@ -306,7 +306,8 @@ class Status:
         self.log(f'Architecture: {model.__class__.__name__}:\n{model}')
 
     def log_gpu_memory(self, stage: str=None, at: list[int]|int=None, as_hook: bool=False) -> None:
-        """log memory summary.
+        """log memory summary. Optionally this function returns a executable hook that logs GPU memory when called.
+        Useful for registering this function as a hook for `OptimizerStep`
 
         Args:
             stage (str, optional): The name of the stage to summarize VRAM. Default: None.


### PR DESCRIPTION
# WHAT

Closes #94 

## Changes
- Add `as_hook` option to `status.Status.log_gpu_memory`.
  - If `True`, returns a function with no arguments that logs GPU memory when called. This hook can be registered to `OptimizerStep`.
- Add arguments to `torchops.get_optimizer_step` for registering hooks.