### PR TITLE
Cleanup

### DIFF
--- a/storch/_optimizer_step.py
+++ b/storch/_optimizer_step.py
@@ -43,7 +43,54 @@ def get_optimizer_step(
     module: nn.Module=None,
     post_backward_hooks: list[Callable]=[],
     post_optim_step_hooks: list[Callable]=[]
-):
+) -> Callable:
+    """creates a function that:
+
+    - Calls `backward` on the loss.
+
+    - Calls `step` on the optimizer.
+
+    - Calls `step` on scheduler if given.
+
+    - Optionally zeros the gradients.
+
+    - Optionally set gradients to `None`.
+
+        - (This is the default behavior after pytorch>=2.0.0 ([PR](https://github.com/pytorch/pytorch/pull/92731)))
+
+    - Optionally clips gradients by gradient norm.
+
+    - Optionally calls `update` on `GradScaler` for native AMP.
+
+    - Automatically takes care of gradient accumulation.
+
+    with one function call.
+
+    Zeroing gradients and updating `GradScaler` is optional for flexibility. Especially, when you have multiple
+    optimizers, you might want to update the `GradScaler` only once per optimization step.
+
+    The scheduler is always updated if it is passed as an argument, so if your scheduler assumes updating on every
+    epoch, you should call them manually, outside of this function.
+
+    Args:
+        trigger_gradient_scaling_via_gradscaler (bool, optional): deprecated argument. Default: False.
+        gradient_accumulation_steps (int, optional): gradient accumulation steps. Default: 1.
+        num_iters_per_epoch (int, optional): number of iterations per epoch. This is used to set the gradient
+            accumulation steps for the last few batches. If `None`, assumes that the dataset is infinite. Default: None.
+        no_sync_context (Callable, optional): context manager for no gradient synchronization. This will speedup
+            gradient accumulation by disabling device synchronization which is performed on every `backward` call.
+            This argument is optional and gradient accumulation will work perfectly fine without this argument.
+            Alternatively you can pass the module to optimize to automatically find `no_sync`. Default: None.
+        module (nn.Module, optional): Use this argument to automatically find if `no_sync` method is available.
+            This argument will be ignored when `no_sync_context` is given. Default: None.
+        post_backward_hooks (list[Callable], optional): list of functions to be called after calling backward on
+            the loss. The function must not require any arguments. Default: [].
+        post_optim_step_hooks (list[Callable], optional): list of functions to be called after calling step on the
+            optimizer. The function must not require any arguments. Default: [].
+
+    Returns:
+        Callable: Optimizer step function.
+    """
 
     if module is not None and no_sync_context is None:
         no_sync_context = getattr(module, 'no_sync', None)
@@ -150,6 +197,34 @@ class OptimizerStep:
         clip_grad_norm: bool=False, max_norm: float=1.0, grad_nan_to_num: bool=False,
     ) -> None:
         """optimization step which supports gradient scaling for AMP.
+
+        Supporting functionalities:
+
+        - Calls `backward` on the loss.
+
+        - Calls `step` on the optimizer.
+
+        - Calls `step` on scheduler if given.
+
+        - Optionally zeros the gradients.
+
+        - Optionally set gradients to `None`.
+
+            - (This is the default behavior after pytorch>=2.0.0 ([PR](https://github.com/pytorch/pytorch/pull/92731)))
+
+        - Optionally clips gradients by gradient norm.
+
+        - Optionally calls `update` on `GradScaler` for native AMP.
+
+        - Automatically takes care of gradient accumulation.
+
+        with one function call.
+
+        Zeroing gradients and updating `GradScaler` is optional for flexibility. Especially, when you have multiple
+        optimizers, you might want to update the `GradScaler` only once per optimization step.
+
+        The scheduler is always updated if it is passed as an argument, so if your scheduler assumes updating on every
+        epoch, you should call them manually, outside of this function.
 
         Args:
             loss (torch.Tensor): loss to backpropagate.

--- a/storch/_optimizer_step.py
+++ b/storch/_optimizer_step.py
@@ -247,8 +247,3 @@ class OptimizerStep:
 
         if update_scaler:
             scaler.update()
-
-
-# aliases for backward compat
-optimizer_step = simple_optimizer_step = OptimizerStep(gradient_accumulation_steps=1)
-optimizer_step_with_gradient_accumulation = simple_optimizer_step_with_gradient_accumulation = OptimizerStep

--- a/storch/checkpoint.py
+++ b/storch/checkpoint.py
@@ -18,6 +18,20 @@ from storch.path import Path
 class Checkpoint:
     """class for saving checkpoints.
 
+    Easy saving/loading of intermediate training procedure. The main API of this class is three functions:
+
+    - `register`: register objects which have `state_dict` and `load_state_dict` methods.
+
+    - `save`: serialize the registered model.
+
+    - `load`/`load_latest`: load (latest) checkpoint.
+
+    `save` and `load_latest` does not have any required arguments.
+
+    This class automatically saves/loads the random state of python builtin `random`, numpy, and PyTorch.
+
+    Supports distributed training (serialization only on primary process).
+
     Args:
         folder (str): folder to save the checkpoints to.
         keep_last (int, optional): keep last n checkpoints. None to keep all. Default: 3.

--- a/storch/dataset/__init__.py
+++ b/storch/dataset/__init__.py
@@ -1,5 +1,6 @@
 
 from storch.dataset.dataset import (DatasetBase, ImageFolder, ImageFolders,
-                                    ImagePathFile, ImagePathFiles)
+                                    ImagePathFile, ImagePathFiles, _collect_image_paths)
 from storch.dataset.transform import (make_simple_transform,
                                       make_transform_from_config)
+from storch.dataset.utils import is_image_file

--- a/storch/dataset/utils.py
+++ b/storch/dataset/utils.py
@@ -10,6 +10,7 @@ import storch
 # from https://github.com/pytorch/vision/blob/6512146e447b69cc9fb379eb05e447a17d7f6d1c/torchvision/datasets/folder.py#L242
 IMG_EXTENSIONS = {".jpg", ".jpeg", ".png", ".ppm", ".bmp", ".pgm", ".tif", ".tiff", ".webp"}
 
+
 def is_image_file(path: str) -> bool:
     """Returns whether if the path is a PIL.Image.Image openable file
 
@@ -21,6 +22,7 @@ def is_image_file(path: str) -> bool:
     """
     ext = set([os.path.splitext(os.path.basename(path))[-1].lower()])
     return ext.issubset(IMG_EXTENSIONS)
+
 
 def get_loader_kwargs() -> storch.EasyDict:
     """loader keyword arguments.
@@ -38,12 +40,12 @@ def get_loader_kwargs() -> storch.EasyDict:
     loader_kwargs.generator      = None
     return loader_kwargs
 
-def is_tensor(data):
-    return isinstance(data, torch.Tensor)
+
 def to(data, device):
     return data.to(device)
 
+
 def device_placement_collate_fn(batch, device):
     batch = default_collate(batch)
-    batch = storch.recursive_apply(partial(to, device=device), batch, is_tensor)
+    batch = storch.recursive_apply(partial(to, device=device), batch, torch.is_tensor)
     return batch

--- a/storch/debug.py
+++ b/storch/debug.py
@@ -23,6 +23,7 @@ from storch.torchops import print_module_summary
 __all__ = [
     'np',
     'torch',
+    'nn',
     'dummy_tensor',
     'save_image',
     'save_images',

--- a/storch/distributed/__init__.py
+++ b/storch/distributed/__init__.py
@@ -1,1 +1,2 @@
 from storch.distributed.helper import DistributedHelper
+from storch.distributed.utils import *

--- a/storch/distributed/factory/ddp.py
+++ b/storch/distributed/factory/ddp.py
@@ -1,31 +1,77 @@
 """container for DDP modules"""
 
+from __future__ import annotations
+
 from collections import OrderedDict
 
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.optim.optimizer import Optimizer
 
 from storch.distributed.factory._base import (CheckpointInterfaceBase,
                                               ParallelFactoryBase)
 
 
 class DDPModuleCheckpointInterface(CheckpointInterfaceBase):
+    """Interface for checkpointing models wrapped with DDP. This class will be constructed automatically
+    by `distributed.DistributedHelper.prepare_for_checkpointing`.
 
-    def state_dict(self):
+    DDP models holds the original model at `.module` attribute. Getting and setting the state_dict can
+    be achieved by accessing this attr.
+    If this is not done, all of the parameters' key will contain `module.` prefix, and we will have to
+    erase this prefix when loading parameters to non-parallelized models. This interface provides methods
+    to easily get/set the state_dict dealing with parameter names.
+
+    Args:
+        to_checkpoint (nn.Module): The module to wrap witch this interface.
+    """
+
+    def state_dict(self) -> OrderedDict:
+        """This function returns the state_dict of the original module.
+
+        Returns:
+            OrderedDict: the state_dict
+        """
         return self.to_checkpoint.module.state_dict()
 
-    def load_state_dict(self, state_dict: OrderedDict):
+    def load_state_dict(self, state_dict: OrderedDict) -> None:
+        """This function properly sets the state_dict to the parallelized model.
+
+        Args:
+            state_dict (OrderedDict): The non-parallelized model's state_dict to load.
+        """
         self.to_checkpoint.module.load_state_dict(state_dict)
 
 
 class DistributedDataParallelFactory(ParallelFactoryBase):
+    """Factory class that provides methods to wrap the input model with the pytorch native DDP class and
+    creates interfaces for checkpointing. This class is only used inside `distributed.DistributedHelper`,
+    and users should not be seeing this class from code.
+    """
+    def wrap_module(self, module: nn.Module, device_ids: list=None, **kwargs) -> DDP:
+        """This funcion wraps the input `module` using pytorch native DDP class.
 
-    def wrap_module(self, module: nn.Module, device_ids: list=None, **kwargs):
+        Args:
+            module (nn.Module): module to wrap.
+            device_ids (list): device ids.
+
+        Returns:
+            DDP: the wrapped module.
+        """
         wrapped_module = DDP(module, device_ids=device_ids)
         self._wrapped_module = wrapped_module
         return wrapped_module
 
-    def create_checkpoint_interface(self, optim, **kwargs):
+    def create_checkpoint_interface(self, optim: Optimizer, **kwargs) -> tuple[DDPModuleCheckpointInterface, Optimizer]:
+        """Create interfaces for checkpointing. DDP does not require code changes for optimizers so they,
+        are returned as-is.
+
+        Args:
+            optim (Optimizer): The corresponding optimizer for training the wrapped module.
+
+        Returns:
+            tuple[DDPModuleCheckpointInterface, Optimizer]: Interface for checkpointing and the optimizer.
+        """
         assert self.is_wrapped, f'Call "wrap_module()" first.'
         module_interface = DDPModuleCheckpointInterface(self._wrapped_module)
         return module_interface, optim

--- a/storch/distributed/factory/nodp.py
+++ b/storch/distributed/factory/nodp.py
@@ -6,6 +6,7 @@ from storch.distributed.factory._base import ParallelFactoryBase
 
 
 class NoParallelFactory(ParallelFactoryBase):
+    """Dummy class for no distributed training."""
 
     def wrap_module(self, module: nn.Module, **kwargs):
         self._wrapped_module = module

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -53,17 +53,21 @@ class DistributedHelper:
 
     @staticmethod
     def is_available() -> bool:
+        """is distributed module available?"""
         return dist.is_available()
 
     @staticmethod
     def is_initialized() -> bool:
+        """is distributed process group initialized?"""
         return dist.is_initialized()
 
     @staticmethod
     def is_torchrun() -> bool:
+        """was python launched using `torchrun` command?"""
         return dist.is_torchelastic_launched()
 
     def is_primary(self) -> bool:
+        """is the process the primary process."""
         return self._state.is_main_process
 
     # gather functions.
@@ -129,22 +133,28 @@ class DistributedHelper:
     reduce = reduce_any
 
     def reduce_sum(self, val: Any) -> torch.Tensor:
+        """reduce distributed tensors by summation"""
         return self.reduce_any(val)
 
     def reduce_mean(self, val: Any) -> torch.Tensor:
+        """reduce distributed tensors by taking the average"""
         return self.reduce_any(val, ReduceOp.AVG)
 
     def reduce_prod(self, val: Any) -> torch.Tensor:
+        """reduce distributed tensors by production"""
         return self.reduce_any(val, ReduceOp.PRODUCT)
 
     def reduce_min(self, val: Any) -> torch.Tensor:
+        """reduce distributed tensors by taking the minmum"""
         return self.reduce_any(val, ReduceOp.MIN)
 
     def reduce_max(self, val: Any) -> torch.Tensor:
+        """reduce distributed tensors by taking the maximum"""
         return self.reduce_any(val, ReduceOp.MAX)
 
     @staticmethod
     def barrier():
+        """syncronize all processes."""
         utils.wait_for_everyone()
 
     @staticmethod
@@ -154,7 +164,20 @@ class DistributedHelper:
         utils.wait_for_everyone()
 
 
-    def get_parallel_mode(self, mode: str=None):
+    def get_parallel_mode(self, mode: str=None) -> str:
+        """get parallelizm strategy. The user should always call this function to get the strategy,
+        because this function forces the `_mode` attr to be set only once.
+
+        If mode is not set, initialize the `_mode` attribute using the given `mode` argument. if
+        `mode is None`, we fallback to `'ddp'` which is more stable than FSDP. If `_mode` attr is
+        already set, returns the value of `_mode`.
+
+        Args:
+            mode (str, optional): the parallelizm mode. Default: None.
+
+        Returns:
+            str: a string representing the parallelizm strategy.
+        """
         if self._mode is None:
             if mode is None:
                 mode = 'ddp'
@@ -245,7 +268,8 @@ class DistributedHelper:
     def prepare_dataset(self, dataset: Dataset, batch_size: int, shuffle: bool=True, drop_last: bool=True,
         num_workers: int=0, pin_memory: bool=True, worker_init_fn: Callable=None, generator: torch.Generator=None
     ) -> DataLoader:
-        """prepare dataset, given dataloader parameters.
+        """prepare dataset, given dataloader parameters. If the distributed packae is initialized, `DistributedSampler`
+        is used as the `sampler`.
 
         Args:
             dataset (Dataset): Dataset

--- a/storch/distributed/utils.py
+++ b/storch/distributed/utils.py
@@ -28,10 +28,12 @@ __all__ = [
 
 
 def is_available() -> bool:
+    """is distributed package available?"""
     return dist.is_available()
 
 
 def is_torchrun() -> bool:
+    """is python started via torchrun command?"""
     return dist.is_torchelastic_launched()
 
 

--- a/storch/distributed/utils.py
+++ b/storch/distributed/utils.py
@@ -22,7 +22,8 @@ __all__ = [
     'get_local_rank',
     'get_device',
     'gather',
-    'reduce'
+    'reduce',
+    'only_on_primary'
 ]
 
 

--- a/storch/layers/__init__.py
+++ b/storch/layers/__init__.py
@@ -11,4 +11,5 @@ from storch.layers.normalization import (AdaptiveNorm2d, LayerNorm2d,
                                          get_normalization2d)
 from storch.layers.squeezeexcitation import (
     ChannelSqueezeAndExcitation, SpatialChannelSqueezeAndExcitation,
-    SpatialSqueezeAndExcitation, cSE, scSE, sSE)
+    SpatialSqueezeAndExcitation, cSE, scSE, sSE, SE)
+from storch.layers.transformer import MetaformerBlock

--- a/storch/layers/activation.py
+++ b/storch/layers/activation.py
@@ -2,11 +2,8 @@
 import torch.nn as nn
 
 
-def get_activation(name: str) -> nn.Module:
-    """Get activation layer by name
-
-    NOTE: - Always inplace=True.
-          - negative_slope=0.2 for LeakyReLU
+def get_activation(name: str, **kwargs) -> nn.Module:
+    """Get activation layer by name.
 
     Args:
         name (str): Name of the activation function.
@@ -17,11 +14,11 @@ def get_activation(name: str) -> nn.Module:
     Returns:
         nn.Module: The activation function module.
     """
-    if   name == 'relu':  return nn.ReLU(True)
-    elif name == 'lrelu': return nn.LeakyReLU(0.2, True)
-    elif name == 'prelu': return nn.PReLU()
-    elif name == 'gelu':  return nn.GELU()
-    elif name in ['swish', 'silu']: return nn.SiLU(True)
-    elif name == 'tanh':  return nn.Tanh()
-    elif name == 'sigmoid': return nn.Sigmoid()
+    if   name == 'relu':  return nn.ReLU(**kwargs)
+    elif name == 'lrelu': return nn.LeakyReLU(**kwargs)
+    elif name == 'prelu': return nn.PReLU(**kwargs)
+    elif name == 'gelu':  return nn.GELU(**kwargs)
+    elif name in ['swish', 'silu']: return nn.SiLU(**kwargs)
+    elif name == 'tanh':  return nn.Tanh(**kwargs)
+    elif name == 'sigmoid': return nn.Sigmoid(**kwargs)
     raise Exception(f'Activation: {name}')

--- a/storch/layers/activation.py
+++ b/storch/layers/activation.py
@@ -5,11 +5,21 @@ import torch.nn as nn
 def get_activation(name: str, **kwargs) -> nn.Module:
     """Get activation layer by name.
 
+    Supported functions:
+      - `relu`: `torch.nn.ReLU`
+      - `lrelu`: `torch.nn.LeakyReLU`
+      - `prelu`: `torch.nn.PReLU`
+      - `gelu`: `torch.nn.GELU`
+      - `silu`: `torch.nn.SiLU`
+      - `tanh`: `torch.nn.Tanh`
+      - `sigmoid`: `torch.nn.Sigmoid`
+
     Args:
         name (str): Name of the activation function.
+        **kwargs: keyword arguments for the activation functions.
 
     Raises:
-        Exception: Unknown name.
+        Exception: Unknown activation name.
 
     Returns:
         nn.Module: The activation function module.

--- a/storch/layers/convolution.py
+++ b/storch/layers/convolution.py
@@ -22,6 +22,7 @@ class DepthWiseConv2d(nn.Conv2d):
             channels, channels, kernel_size, stride=stride, padding=padding,
             dilation=dilation, groups=channels, bias=bias, padding_mode=padding_mode)
 
+
 class PointWiseConv2d(nn.Conv2d):
     """Point-wise convolution 2d is a convolution layer with 1x1 kernel.
 
@@ -34,6 +35,7 @@ class PointWiseConv2d(nn.Conv2d):
         in_channels: int, out_channels: int, bias: bool=True
     ) -> None:
         super().__init__(in_channels, out_channels, 1, bias=bias)
+
 
 class DepthSepConv2d(nn.Module):
     """Depth-wise separable convolution 2d splits the convolution to depth-wise convolution and

--- a/storch/layers/interpolation.py
+++ b/storch/layers/interpolation.py
@@ -27,6 +27,7 @@ def _make_blur_kernel(filter_size: int) -> torch.Tensor:
     filter2d /= filter2d.sum()
     return filter2d.unsqueeze(0).unsqueeze(0)
 
+
 class Blur(nn.Module):
     """Blur layer used in StyleGANs
 
@@ -53,6 +54,7 @@ class Blur(nn.Module):
     def extra_repr(self):
         return f'filter_size={self._filter_size}'
 
+
 class BlurUpsample(nn.Sequential):
     """Upsample then blur.
 
@@ -68,6 +70,7 @@ class BlurUpsample(nn.Sequential):
         super().__init__(
             nn.Upsample(scale_factor=scale_factor, mode=mode, align_corners=align_corners),
             Blur(filter_size))
+
 
 class BlurDownsample(nn.Sequential):
     """Blur then downsample

--- a/storch/layers/normalization.py
+++ b/storch/layers/normalization.py
@@ -27,6 +27,7 @@ def get_normalization2d(name: str, channels: int, **kwargs) -> nn.Module:
         return nn.GroupNorm(num_channels=channels, **kwargs)
     raise Exception(f'Normalization: {name}')
 
+
 def get_normalization1d(name: str, channels: int, **kwargs) -> nn.Module:
     """Get 1d normalization layers by name
 

--- a/storch/layers/squeezeexcitation.py
+++ b/storch/layers/squeezeexcitation.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from storch.layers import get_activation
 
 
-class SpatialSqueezeAndExcitation(nn.Module):
+class SpatialSqueezeAndChannelExcitation(nn.Module):
     """Spatial squeeze and excitation block.
     This is equivalent to the original squeeze and excitation block, but with some options.
 
@@ -34,7 +34,7 @@ class SpatialSqueezeAndExcitation(nn.Module):
         return x
 
 
-class ChannelSqueezeAndExcitation(nn.Module):
+class ChannelSqueezeAndSpatialExcitation(nn.Module):
     """Channel squeeze and excitation block.
     Attention.
 
@@ -54,6 +54,7 @@ class ChannelSqueezeAndExcitation(nn.Module):
         x = x * self.global_content(x)
         return x
 
+
 class SpatialChannelSqueezeAndExcitation(nn.Module):
     """Spatial channel squeeze and excitation block.
 
@@ -67,8 +68,8 @@ class SpatialChannelSqueezeAndExcitation(nn.Module):
         channels: int, reduction: int=4, pool_size: int=1, act_name: str='relu'
     ) -> None:
         super().__init__()
-        self.spatial_se = SpatialSqueezeAndExcitation(channels, reduction, pool_size, act_name)
-        self.channel_se = ChannelSqueezeAndExcitation(channels)
+        self.spatial_se = SpatialSqueezeAndChannelExcitation(channels, reduction, pool_size, act_name)
+        self.channel_se = ChannelSqueezeAndSpatialExcitation(channels)
 
     def forward(self, x):
         s = self.spatial_se(x)
@@ -78,6 +79,6 @@ class SpatialChannelSqueezeAndExcitation(nn.Module):
 
 
 # alias
-sSE = SpatialSqueezeAndExcitation
-cSE = ChannelSqueezeAndExcitation
+SE = cSE = SpatialSqueezeAndChannelExcitation
+sSE = ChannelSqueezeAndSpatialExcitation
 scSE = SpatialChannelSqueezeAndExcitation

--- a/storch/layers/transformer.py
+++ b/storch/layers/transformer.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 
 
-class TransformerBlock(nn.Module):
+class MetaformerBlock(nn.Module):
     """Pass in nn.Module objects to construct a transformer block
 
     Configuration:
@@ -11,26 +11,26 @@ class TransformerBlock(nn.Module):
         - trainable layer scaling with initial value of 1e-2
 
     Args:
-        attention (nn.Module): nn.Module which implements an attention.
+        token_mixer (nn.Module): nn.Module which implements an attention.
         feedforward (nn.Module): nn.Module which implements a feed forward network.
         norm_layer1 (nn.Module): Normalization layer applied before the attention.
         norm_layer2 (nn.Module): Normalization layer applied before the feed forward network.
     """
     def __init__(self,
-        attention: nn.Module, feedforward: nn.Module, norm_layer1: nn.Module, norm_layer2: nn.Module
+        token_mixer: nn.Module, feedforward: nn.Module, norm_layer1: nn.Module, norm_layer2: nn.Module
     ) -> None:
         super().__init__()
-        should_be_module = (attention, feedforward, norm_layer1, norm_layer2)
+        should_be_module = (token_mixer, feedforward, norm_layer1, norm_layer2)
         assert all([isinstance(module, nn.Module) for module in should_be_module])
         self.norm1       = norm_layer1
-        self.attention   = attention
+        self.token_mixer = token_mixer
         self.norm2       = norm_layer2
         self.feedforward = feedforward
 
-        self.scale_attn = nn.Parameter(torch.ones([]) * 1e-2)
-        self.scale_ff   = nn.Parameter(torch.ones([]) * 1e-2)
+        self.scale_mixer = nn.Parameter(torch.ones([]) * 1e-2)
+        self.scale_ff    = nn.Parameter(torch.ones([]) * 1e-2)
 
     def forward(self, x):
-        x = x + self.scale_attn * self.attention(self.norm1(x))
-        x = x + self.scale_ff   * self.feedforward(self.norm2(x))
+        x = x + self.scale_mixer * self.token_mixer(self.norm1(x))
+        x = x + self.scale_ff    * self.feedforward(self.norm2(x))
         return x

--- a/storch/models/model_utils.py
+++ b/storch/models/model_utils.py
@@ -12,6 +12,8 @@ import torch.nn as nn
 from torch.cuda.amp import GradScaler
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
+from stutil.exceptions import deprecated
+
 
 from storch._optimizer_step import get_optimizer_step
 from storch.utils import version
@@ -163,6 +165,7 @@ def register_init_args(init):
     return inner
 
 
+@deprecated('nest.NeST', 'nest.NeST')
 class Engine:
     """engine for training.
 

--- a/storch/project/utils.py
+++ b/storch/project/utils.py
@@ -6,7 +6,7 @@ from typing import Callable
 from omegaconf import DictConfig, OmegaConf
 
 from storch import get_now_string
-from storch.distributed import DistributedHelper
+from storch.distributed import DistributedHelper, is_primary
 from storch.hydra_utils import get_hydra_config, save_hydra_config
 from storch.path import Folder, Path
 
@@ -74,7 +74,7 @@ def init_run(
         folder: Folder = get_folder_from_config(config)
         if child_folders != {}:
             folder.add_children(**child_folders)
-        if disthelper is None or disthelper.is_primary():
+        if is_primary():
             folder.mkdir()
             if save_config:
                 save_hydra_config(config, folder.root / config_file)

--- a/storch/torchops.py
+++ b/storch/torchops.py
@@ -28,7 +28,6 @@ __all__ = [
     'unfreeze',
     'update_ema',
     'set_seeds',
-    'deterministic',
     'shuffle_batch',
     'get_optimizer_step',
     'optimizer_step',
@@ -182,26 +181,6 @@ def set_seeds(
     generator.manual_seed(0)
 
     return seed_worker, generator
-
-
-def deterministic(seed: int=3407) -> tuple[Callable, torch.Generator]:
-    """Settings for reproducible training.
-
-    Deprecated
-
-    Args:
-        seed (int, optional): Random number generator seed. Default: 3407.
-
-    Returns:
-        Callable: Function for DataLoader's worker_init_fn option.
-        torch.Generator: torch.Generator for DataLoader's generator option.
-    """
-    import warnings
-    warnings.warn(
-        f'"deterministic" is deprecated in favor of "set_seeds" and will be erased in the future version.',
-        DeprecationWarning
-    )
-    set_seeds(seed, use_deterministic_algorithms=True)
 
 
 def shuffle_batch(batch: torch.Tensor, return_permutation: bool=False) -> Union[tuple[torch.Tensor, torch.Tensor], torch.Tensor]:

--- a/storch/trainutils/__init__.py
+++ b/storch/trainutils/__init__.py
@@ -12,11 +12,7 @@ from storch.scheduler import build_scheduler
 from storch.status import Status, ThinStatus
 from storch.torchops import (auto_get_device, freeze, get_grad_scaler,
                              get_optimizer_step, inference_mode,
-                             optimizer_step,
-                             optimizer_step_with_gradient_accumulation,
-                             set_seeds, simple_optimizer_step,
-                             simple_optimizer_step_with_gradient_accumulation,
-                             unfreeze, update_ema)
+                             set_seeds, unfreeze, update_ema)
 
 __all__ = [
     'loss',
@@ -34,11 +30,7 @@ __all__ = [
     'build_scheduler',
     'Status',
     'ThinStatus',
-    'optimizer_step',
     'get_optimizer_step',
-    'simple_optimizer_step',
-    'optimizer_step_with_gradient_accumulation',
-    'simple_optimizer_step_with_gradient_accumulation',
     'get_grad_scaler',
     'freeze',
     'unfreeze',


### PR DESCRIPTION
# WHAT

Fixes #93 

## Changes
- Add/update docstrings.
- Remove deprecated features.
- Deprecate features.

## Deprecations
- `models.model_utils.Engine` is deprecated in favor of #91 .

## Changes (backward incompatible)
- Old `optimizer_step` functions are now erased. Use `OptimizerStep` class which can be created via `get_optimizer_step` factory function.
- Deprectaed function `torchops.deterministic` is now erased. Use `torchops.set_seeds` instead.
