### PR TITLE
Transforms

### DIFF
--- a/storch/dataset/__init__.py
+++ b/storch/dataset/__init__.py
@@ -2,5 +2,5 @@
 from storch.dataset.dataset import (DatasetBase, ImageFolder, ImageFolders,
                                     ImagePathFile, ImagePathFiles, _collect_image_paths)
 from storch.dataset.transform import (make_simple_transform,
-                                      make_transform_from_config)
+                                      make_transform_from_config, make_cutmix_or_mixup)
 from storch.dataset.utils import is_image_file

--- a/storch/transforms/v2.py
+++ b/storch/transforms/v2.py
@@ -5,7 +5,12 @@ import cv2
 import numpy as np
 import torch
 from PIL import Image
-from torchvision import datapoints
+
+from storch.utils.version import is_v2_transforms_available
+if not is_v2_transforms_available():
+    raise Exception(f'v2 transforms is not available. Use torchvision>=0.16.0.')
+
+from torchvision import tv_tensors
 from torchvision.transforms.v2 import Transform
 from torchvision.transforms.v2 import functional as F
 
@@ -16,14 +21,14 @@ from storch.transforms.degradations import (all_kernels, random_gaussian_noise,
 from storch.transforms.resize_right import resize
 
 
-def to_image_dp(image: Image.Image, dtype: torch.dtype=torch.float) -> datapoints.Image:
-    image = datapoints.Image(image)
-    image = F.convert_dtype_image_tensor(image, dtype=dtype)
+def to_image(image: Image.Image, dtype: torch.dtype=torch.float) -> tv_tensors.Image:
+    image = F.to_image(image) # PIL -> torch.Tensor (dtype: uint8)
+    image = F.to_dtype(image, dtype=dtype)
     return image
 
 
-def to_mask_dp(mask: Image.Image) -> datapoints.Mask:
-    return datapoints.Mask(mask)
+def to_mask(mask: Image.Image) -> tv_tensors.Mask:
+    return tv_tensors.Mask(mask)
 
 
 class ToNumpy(Transform):
@@ -39,9 +44,9 @@ class ToNumpy(Transform):
         return inpt
 
 
-class ToTenor(Transform):
+class ToTensor(Transform):
     """ToTensor with same functionality as v1 ToTensor class."""
-    _transformed_types = (datapoints.Image, Image.Image)
+    _transformed_types = (tv_tensors.Image, Image.Image)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if isinstance(inpt, Image.Image):

--- a/storch/utils/version.py
+++ b/storch/utils/version.py
@@ -39,3 +39,9 @@ def is_multi_weight_api_available():
 
 def is_compiler_available():
     return is_torch_version_geq('2.0.0')
+
+
+def is_v2_transforms_available():
+    # v2 namespace appeared in v0.15.0, but had some breaking changes in v0.16.0,
+    # so we skip v0.15.x series.
+    return is_torchvision_version_geq('0.16.0')


### PR DESCRIPTION
# WHAT
- Support `torchvision.transforms.v2`.
- Remove support of `v2` when `torchvision==0.15.x`.
- Add `CutMix` and `MixUp` builder function.

## Changes
- Use `0.16.x`'s `v2` api.
- Support `v2` transforms in `dataset.make_transform_from_config`.
- Add `utils.version.is_v2_transforms_available`.
  - This function returns `False` when `torchvision==0.15.x`, which has `v2` namespace. This is beacuse of some changes in the transform api after `0.16.x` series.
- Add `dataset.make_cutmix_or_mixup`.