### PR TITLE
✨ bfloat16

### DIFF
--- a/storch/distributed/factory/fsdp.py
+++ b/storch/distributed/factory/fsdp.py
@@ -7,8 +7,9 @@ from typing import OrderedDict
 
 import torch
 import torch.nn as nn
-from torch.distributed.fsdp import FullStateDictConfig, MixedPrecision, StateDictType
+from torch.distributed.fsdp import FullStateDictConfig
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, StateDictType
 from torch.optim.optimizer import Optimizer
 
 import storch
@@ -156,6 +157,8 @@ class FullyShardedDataParallelFactory(ParallelFactoryBase):
         """
         if mixed_precision:
             dtype = torch.float16
+            if mixed_precision == 'bf16':
+                dtype = torch.bfloat16
             mixed_precision = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
         else:
             mixed_precision = None

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -272,6 +272,8 @@ class DistributedHelper:
             if mixed_precision and self.device.type == 'cuda':
                 wrapped_module._original_forward = wrapped_module.forward
                 dtype = torch.float16
+                if mixed_precision == 'bf16':
+                    dtype = torch.bfloat16
                 forward = torch.cuda.amp.autocast(dtype=dtype)(wrapped_module.forward)
                 wrapped_module.forward = convert_outputs_to_fp32(forward)
 


### PR DESCRIPTION
# WHAT
- Add `bfloat16` support for CUDA devices.

## Changes
- Accepts `bf16` as `mixed_precision` option input.