### PR TITLE
✨ Easier state_dict impl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: requirements-txt-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.9
+    rev: v0.2.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-devel
+FROM pytorch/pytorch:2.2.0-cuda11.8-cudnn8-devel
 
 ENV DEBIAN_FRONTEND=noniteractive
 RUN apt update -y && \

--- a/docker/torch/Dockerfile
+++ b/docker/torch/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-devel
+FROM pytorch/pytorch:2.2.0-cuda11.8-cudnn8-devel
 
 ENV DEBIAN_FRONTEND=noniteractive
 RUN apt update -y && \

--- a/docker/torch/requirements.txt
+++ b/docker/torch/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/STomoya/stutil@v0.0.5
+git+https://github.com/STomoya/stutil@v0.0.6
 hydra-core
 matplotlib
 opencv-python

--- a/storch/_optimizer_step.py
+++ b/storch/_optimizer_step.py
@@ -25,6 +25,7 @@ def grad_nan_to_num_(
         nan (float, optional): Value to replace nan. Default: 0.0.
         posinf (float, optional): Value to replace positive inf. Default: 1e5.
         neginf (float, optional): Value to replace negative inf. Default: 1e-5.
+
     """
     if isinstance(input, nn.Module):
         input = input.parameters()
@@ -96,6 +97,7 @@ def get_optimizer_step(
     Returns:
     -------
         Callable: Optimizer step function.
+
     """
     if post_optim_step_hooks is None:
         post_optim_step_hooks = []
@@ -129,6 +131,7 @@ class OptimizerStep:
     Examples:
     --------
         >>> optimizer_step = OptimizerStep(grad_steps, total_iters)
+
     """
 
     def __init__(
@@ -169,6 +172,7 @@ class OptimizerStep:
         ----
             when (str): either 'backward' or 'step'
             *hooks: callables to be executed.
+
         """
         assert when in ['backward', 'step']
         for hook in hooks:
@@ -260,6 +264,7 @@ class OptimizerStep:
             max_norm (float, optional): Maximum norm used when clipping gradients. Default: 1.0.
             grad_nan_to_num (bool, optional): Replace nan gradient: a number. Default: False.
             update_scaler (bool, optional): Update the scaler if not None. Default: False.
+
         """
         if clip_grad_norm or grad_nan_to_num:
             _assert_require_module(module)

--- a/storch/algorithms/cutmix.py
+++ b/storch/algorithms/cutmix.py
@@ -19,6 +19,7 @@ def random_box(size: tuple, lambda_: float) -> tuple[tuple[int], float]:
     -------
         tuple[int]: xyxy
         float: adjusted lambda
+
     """
     W = size[0]
     H = size[1]
@@ -58,6 +59,7 @@ def cutmix(
         torch.Tensor: The mixed image.
         torch.Tensor: The target in the order of the shuffled images.
         torch.Tensor: The lambda used to make the mask.
+
     """
     B, _, W, H = images.size()
 
@@ -101,6 +103,7 @@ def mixed_cross_entropy_loss(
     Returns:
     -------
         torch.Tensor: the loss
+
     """
     ce_loss_a = F.cross_entropy(logits, targets_a, reduction='none') * lambdas
     ce_loss_b = F.cross_entropy(logits, targets_b, reduction='none') * (1 - lambdas)

--- a/storch/algorithms/cutout.py
+++ b/storch/algorithms/cutout.py
@@ -20,6 +20,7 @@ def random_box(size: tuple, lambda_: float) -> tuple[tuple[int], float]:
     -------
         tuple[int]: xyxy
         float: adjusted lambda
+
     """
     W = size[0]
     H = size[1]
@@ -57,6 +58,7 @@ def cutout(
     Returns:
     -------
         torch.Tensor: The mixed image.
+
     """
     B, C, W, H = images.size()
 

--- a/storch/algorithms/mixup.py
+++ b/storch/algorithms/mixup.py
@@ -26,6 +26,7 @@ def mixup(
         torch.Tensor: The mixed image.
         torch.Tensor: The target in the order of the shuffled images.
         torch.Tensor: The lambda used to make the mask.
+
     """
     B = images.size(0)
 
@@ -60,6 +61,7 @@ def mixed_cross_entropy_loss(
     Returns:
     -------
         torch.Tensor: the loss
+
     """
     ce_loss_a = F.cross_entropy(logits, targets_a, reduction='none') * lambdas
     ce_loss_b = F.cross_entropy(logits, targets_b, reduction='none') * (1 - lambdas)

--- a/storch/algorithms/realesr.py
+++ b/storch/algorithms/realesr.py
@@ -72,6 +72,7 @@ class RealESRTransform(nn.Module):
         ----
             scale (float): scale
             **kwargs: See RealESRTransformsConfig.
+
         """
         super().__init__()
 

--- a/storch/algorithms/trapped_ball.py
+++ b/storch/algorithms/trapped_ball.py
@@ -22,6 +22,7 @@ def get_ball_structuring_element(radius: int) -> np.ndarray:
     ---------
         radius: int
             Radius of ball shape.
+
     """
     return cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * radius + 1, 2 * radius + 1))
 
@@ -33,6 +34,7 @@ def get_unfilled_point(image: np.ndarray) -> np.ndarray:
     ---------
         image: np.ndarray
             an image.
+
     """
     y, x = np.where(image == 255)  # noqa: PLR2004
     return np.stack((x.astype(int), y.astype(int)), axis=-1)
@@ -51,6 +53,7 @@ def exclude_area(image: np.ndarray, radius: int) -> np.ndarray:
             an image.
         radius: int
             radius of ball shape.
+
     """
     return cv2.morphologyEx(image, cv2.MORPH_ERODE, get_ball_structuring_element(radius), anchor=(-1, -1), iterations=1)
 
@@ -67,6 +70,7 @@ def trapped_ball_fill_single(image: np.ndarray, seed_point: tuple[int, int], rad
             seed point for trapped-ball fill, a tuple (integer, integer).
         radius: int
             radius of ball shape.
+
     """
     ball = get_ball_structuring_element(radius)
 
@@ -106,6 +110,7 @@ def trapped_ball_fill_multi(image: np.ndarray, radius: int, method: str = 'mean'
             'max' is usually with large radius for select large area such as background.
         max_iter: int (default: 1000)
             max iteration number.
+
     """
     unfill_area = image
     filled_area, filled_area_size, result = [], [], []
@@ -151,6 +156,7 @@ def flood_fill_single(im: np.ndarray, seed_point: tuple[int, int]) -> np.ndarray
             the white area is unfilled area, and the black area is filled area.
         seed_point: tuple[int, int]
             seed point for trapped-ball fill, a tuple (integer, integer).
+
     """
     pass1 = np.full(im.shape, 255, np.uint8)
 
@@ -174,6 +180,7 @@ def flood_fill_multi(image, max_iter=20000) -> np.ndarray:
             the white area is unfilled area, and the black area is filled area.
         max_iter: int (default: 20000)
             max iteration number.
+
     """
     unfill_area = image
     filled_area = []
@@ -201,6 +208,7 @@ def mark_fill(image: np.ndarray, fills: list[np.ndarray]) -> np.ndarray:
             an image.
         fills: list[np.ndarray]
             an array of fills' points.
+
     """
     result = image.copy()
 
@@ -219,6 +227,7 @@ def build_fill_map(image: np.ndarray, fills: np.ndarray) -> np.ndarray:
             an image.
         fills: np.ndarray
             an array of fills' points.
+
     """
     result = np.zeros(image.shape[:2], np.int64)
 
@@ -234,6 +243,7 @@ def show_fill_map(fillmap: np.ndarray) -> np.ndarray:
     Arguments:
     ---------
         fillmap: np.ndarray
+
     """
     # Generate color for each fill randomly.
     colors = np.random.randint(0, 255, (np.max(fillmap) + 1, 3))
@@ -250,6 +260,7 @@ def get_bounding_rect(points: np.ndarray) -> tuple[int, int, int, int]:
     ---------
         points: np.ndarray
             array of points.
+
     """
     x1, y1, x2, y2 = np.min(points[1]), np.min(points[0]), np.max(points[1]), np.max(points[0])
     return x1, y1, x2, y2
@@ -272,6 +283,7 @@ def get_border_bounding_rect(
             end point of rect.
         r: int
             border radius.
+
     """
     x1, y1, x2, y2 = p1[0], p1[1], p2[0], p2[1]
 
@@ -298,6 +310,7 @@ def get_border_point(
             image max height.
         max_width: int
             image max width.
+
     """
     # Get a local bounding rect.
     border_rect = get_border_bounding_rect(max_height, max_width, rect[:2], rect[2:], 2)
@@ -333,6 +346,7 @@ def merge_fill(fillmap: np.ndarray, max_iter: int = 10) -> np.ndarray:
             an image.
         max_iter: int (default: 10)
             max iteration number.
+
     """
     max_height, max_width = fillmap.shape[:2]
     result = fillmap.copy()
@@ -398,6 +412,7 @@ def thinning(fillmap: np.ndarray, max_iter: int = 100) -> np.ndarray:
             an image.
         max_iter: int (default: 10)
             max iteration number.
+
     """
     line_id = 0
     h, w = fillmap.shape[:2]
@@ -488,6 +503,7 @@ def trappedball_segmentation(
     -------
         np.ndarray: segment map
         np.ndarray: the filled image.
+
     """
     _, result = cv2.threshold(line_image, threshold, 255, cv2.THRESH_BINARY)
 

--- a/storch/autosave.py
+++ b/storch/autosave.py
@@ -24,6 +24,7 @@ class autosave:
     Attributes
     ----------
         _container (dict): contains the objects to be saved.
+
     """
 
     _container: ClassVar[dict] = {}
@@ -47,6 +48,7 @@ class autosave:
             >>> # model.state_dict() returns a reference so there is no need to overwrite
             >>> # and only needs to be called once
             >>> autosave.register_object('model', model.state_dict())
+
         """
         if overwrite or name not in cls._container:
             cls._container[name] = obj
@@ -70,6 +72,7 @@ class autosave:
             >>> @autosave.register_function_output
             >>> def func():
             >>>     return
+
         """
         name = func.__qualname__
 
@@ -91,6 +94,7 @@ def _save(folder='.'):
     Args:
     ----
         folder (str, optional): The directory to save the registered objects. Default: '.'.
+
     """
     if len(autosave._container.keys()):
         torch.save(autosave._container, os.path.join(folder, 'autosave.torch'))

--- a/storch/checkpoint.py
+++ b/storch/checkpoint.py
@@ -54,6 +54,7 @@ class Checkpoint:
         >>> # this will load the state_dict from the latest checkpoint.
         >>> checkpoint.load_latest()
         {'constant': 1}
+
     """
 
     _container = storch.EasyDict()
@@ -69,6 +70,7 @@ class Checkpoint:
             keep_last (int, optional): keep last n checkpoints. None to keep all. Default: 3.
             filename_format (str, optional): format for filename of the checkpoint. Default: 'checkpoint.{count}.torch'.
             disthelper (None): deprecated.
+
         """
         self.folder = Path(folder)
         self.filename_format = filename_format
@@ -94,6 +96,7 @@ class Checkpoint:
         Returns
         -------
             dict: the state_dict of registered objects.
+
         """
         state_dict = dict()
         for key, value in self._container.items():
@@ -106,6 +109,7 @@ class Checkpoint:
         Returns
         -------
             dict: state_dict of this class.
+
         """
         return dict(storch_version=storch.__version__, file_deque=self.file_deque, count=self.count)
 
@@ -115,6 +119,7 @@ class Checkpoint:
         Args:
         ----
             state_dict (dict): load state_dict to checkpoint object.
+
         """
         _storch_version = state_dict.pop('storch_version')
         if storch.__version__ != _storch_version and distutils.is_primary():
@@ -135,6 +140,7 @@ class Checkpoint:
         Returns
         -------
             str: path to where the checkpoint was saved
+
         """
         filename = self.folder / self.filename_format.format(count=self.count)
         self.file_deque.append(filename)
@@ -176,6 +182,7 @@ class Checkpoint:
         Returns:
         -------
             dict: additional objects saved when save (if any).
+
         """
         distutils.wait_for_everyone()
 
@@ -208,6 +215,7 @@ class Checkpoint:
         Returns:
         -------
             dict: additional objects saved when save (if any).
+
         """
         paths = storch.natural_sort(glob.glob(self.folder / self.filename_format.format(count='*')))
         if len(paths) > 0:
@@ -221,6 +229,7 @@ class Checkpoint:
         Args:
         ----
             **kwargs: objects to be registered as keyword arguments.
+
         """
         not_registered_keys = []
         for key, value in kwargs.items():

--- a/storch/commands/init_project/init_project.py
+++ b/storch/commands/init_project/init_project.py
@@ -41,6 +41,7 @@ def run():
 
     Usage:
         $ python -m storch.commands.init_project
+
     """
     args = get_args()
 

--- a/storch/commands/parameter_sweeper/__main__.py
+++ b/storch/commands/parameter_sweeper/__main__.py
@@ -4,6 +4,7 @@ Examples
 --------
     >>> python -m storch.commands.parameter_sweeper <args>
 
+
 """
 from storch.commands.parameter_sweeper.parameter_sweeper import main
 

--- a/storch/commands/parameter_sweeper/parameter_sweeper.py
+++ b/storch/commands/parameter_sweeper/parameter_sweeper.py
@@ -58,6 +58,7 @@ def _argument_key_to_object_name(key: str) -> str:
       4. --foo-bar => foo_bar
       5. foo.bar   => foo_bar
       6. foo/bar   => foo_bar
+
     """
     if key.startswith('-'):
         key = key.lstrip('-')
@@ -75,6 +76,7 @@ def _argument_key_to_list_name(key: str):
     Returns:
     -------
         str: name of list used in shell script.
+
     """
     object_name = _argument_key_to_object_name(key)
     return object_name + '_list'
@@ -99,6 +101,7 @@ def _convert_value(value: Any, type: str) -> str:
             type=='argparse: [1, 2, 3] => "1 2 3"
         - others:
             str(value)
+
     """
     if type == 'hydra':
         if isinstance(value, list):
@@ -124,6 +127,7 @@ def _for_loop(list_name: str, object_name: str, inner: str) -> str:
     Returns:
     -------
         str: a single for loop script.
+
     """
     iterator = '"${' + list_name + '[@]}"'
     return f'for {object_name} in {iterator}\n' 'do\n' f'{inner}\n' 'done'
@@ -148,6 +152,7 @@ def create_command(command: str, arguments: dict, argument_type: str, include_te
     Returns:
     -------
         str: command with arguments.
+
     """
     command = f'{command}'
     separator = '=' if argument_type == 'hydra' else ' '
@@ -179,6 +184,7 @@ def create_variables(arguments: dict, argument_type: str, excludes: set | None =
     Returns:
     -------
         str: variable definition script
+
     """
     if excludes is None:
         excludes = set()
@@ -207,6 +213,7 @@ def create_for_loop(command: str, arguments: dict, excludes: set | None = None) 
     Returns:
     -------
         str: for loop.
+
     """
     if excludes is None:
         excludes = set()
@@ -239,6 +246,7 @@ def generate_parameter_sweeper_script(
     Returns:
     -------
         str: sweeper script.
+
     """
     if excludes is None:
         excludes = []
@@ -268,6 +276,7 @@ def generate_from_json(path: str, include_test: bool = True) -> str:
     Returns:
     -------
         str: parameter sweeper script.
+
     """
     with open(path, 'r') as fp:
         config = json.load(fp)
@@ -286,6 +295,7 @@ def generate_from_yaml(path: str, include_test: bool = True) -> str:
     Returns:
     -------
         str: parameter sweeper script.
+
     """
     with open(path, 'r') as fp:
         config = yaml.safe_load(fp)

--- a/storch/dataset/dataset.py
+++ b/storch/dataset/dataset.py
@@ -36,6 +36,7 @@ class DatasetBase(Dataset):
         Returns:
         -------
             Self: Other keyword arguments to be passed to the DataLoader class
+
         """
         self.kwargs.batch_size = batch_size
         for key, value in kwargs.items():
@@ -49,6 +50,7 @@ class DatasetBase(Dataset):
         Returns
         -------
             DataLoader: data loader object.
+
         """
         return DataLoader(self, **self.kwargs)
 
@@ -72,6 +74,7 @@ class ImageFolder(DatasetBase):
             Defaul: None.
         filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
             Defaul: None.
+
     """
 
     def __init__(  # noqa: D107
@@ -106,6 +109,7 @@ class ImageFolders(DatasetBase):
             Defaul: None.
         filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
             Defaul: None.
+
     """
 
     def __init__(  # noqa: D107
@@ -142,6 +146,7 @@ class ImageFolders(DatasetBase):
         Args:
         ----
             index (int | None, optional): which to shuffle. If None, both. Default: None.
+
         """
         if index is not None:
             random.shuffle(self.images[index])
@@ -178,6 +183,7 @@ class ImagePathFile(DatasetBase):
             Defaul: None.
         filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
             Defaul: None.
+
     """
 
     def __init__(  # noqa: D107
@@ -218,6 +224,7 @@ class ImagePathFiles(DatasetBase):
             Defaul: None.
         filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
             Defaul: None.
+
     """
 
     def __init__(  # noqa: D107
@@ -253,6 +260,7 @@ class ImagePathFiles(DatasetBase):
         Args:
         ----
             index (int | None, optional): which to shuffle. If None, both. Default: None.
+
         """
         if index is not None:
             random.shuffle(self.images[index])

--- a/storch/dataset/transform.py
+++ b/storch/dataset/transform.py
@@ -39,6 +39,7 @@ def make_simple_transform(
     Returns:
     -------
         Callable: transforms
+
     """
     if isinstance(image_size, int):
         image_size = (image_size, image_size)
@@ -71,6 +72,7 @@ def build_transform(name: str, **params) -> Callable:
     Returns:
     -------
         Callable: the built transform
+
     """
     # convert string to a python object if value starts with 'pyobj:' prefix.
     transform_kwargs = {}
@@ -108,6 +110,7 @@ def make_transform_from_config(configs: list[dict]) -> Callable:
         >>>         {'name': 'Normalize', 'mean': 0.5, 'std': 0.5}
         >>>     ]
         >>> )
+
     """
     transform = []
     for config in configs:
@@ -155,6 +158,7 @@ def make_cutmix_or_mixup(
     Returns:
     -------
         Callable: _description_
+
     """
     if not is_v2_transforms_available():
         # mixup and cutmix was added at `0.16.0`

--- a/storch/dataset/utils.py
+++ b/storch/dataset/utils.py
@@ -23,6 +23,7 @@ def is_image_file(path: str) -> bool:
     Returns:
     -------
         bool: file?
+
     """
     ext = set(os.path.splitext(os.path.basename(path))[-1].lower())
     return ext.issubset(IMG_EXTENSIONS)
@@ -34,6 +35,7 @@ def get_loader_kwargs() -> storch.EasyDict:
     Returns
     -------
         storch.EasyDict: default loader keyword arguments as dict.
+
     """
     loader_kwargs = storch.EasyDict()
     loader_kwargs.batch_size = None
@@ -57,6 +59,7 @@ def to(data: torch.Tensor, device: torch.device) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: tensor on device.
+
     """
     return data.to(device)
 
@@ -72,6 +75,7 @@ def device_placement_collate_fn(batch: Any, device: torch.device) -> Any:
     Returns:
     -------
         Any: The collated batch.
+
     """
     batch = default_collate(batch)
     batch = storch.recursive_apply(partial(to, device=device), batch, torch.is_tensor)

--- a/storch/debug.py
+++ b/storch/debug.py
@@ -58,6 +58,7 @@ def test_model(
         device (str | torch.device, optional): _description_. Defaults to 'cpu'.
         input_sampler (Callable, optional): A callable which is used to sample the dummy inputs.
             Defaults to torch.randn.
+
     """
     if isinstance(models, (list, tuple)):
         assert len(models) == len(input_shapes)

--- a/storch/distributed/factory/__init__.py
+++ b/storch/distributed/factory/__init__.py
@@ -3,3 +3,9 @@
 from storch.distributed.factory.ddp import DistributedDataParallelFactory
 from storch.distributed.factory.fsdp import FullyShardedDataParallelFactory
 from storch.distributed.factory.nodp import NoParallelFactory
+from storch.utils.version import is_dist_state_dict_available
+
+if is_dist_state_dict_available():
+    from storch.distributed.factory import simple
+else:
+    simple = None

--- a/storch/distributed/factory/ddp.py
+++ b/storch/distributed/factory/ddp.py
@@ -24,6 +24,7 @@ class DDPModuleCheckpointInterface(CheckpointInterfaceBase):
     Args:
     ----
         to_checkpoint (nn.Module): The module to wrap witch this interface.
+
     """
 
     def state_dict(self) -> OrderedDict:
@@ -32,6 +33,7 @@ class DDPModuleCheckpointInterface(CheckpointInterfaceBase):
         Returns
         -------
             OrderedDict: the state_dict
+
         """
         return self.to_checkpoint.module.state_dict()
 
@@ -41,6 +43,7 @@ class DDPModuleCheckpointInterface(CheckpointInterfaceBase):
         Args:
         ----
             state_dict (OrderedDict): The non-parallelized model's state_dict to load.
+
         """
         self.to_checkpoint.module.load_state_dict(state_dict)
 
@@ -65,6 +68,7 @@ class DistributedDataParallelFactory(ParallelFactoryBase):
         Returns:
         -------
             DDP: the wrapped module.
+
         """
         wrapped_module = DDP(module, device_ids=device_ids)
         self._wrapped_module = wrapped_module
@@ -83,6 +87,7 @@ class DistributedDataParallelFactory(ParallelFactoryBase):
         Returns:
         -------
             tuple[DDPModuleCheckpointInterface, Optimizer]: Interface for checkpointing and the optimizer.
+
         """
         assert self.is_wrapped, 'Call "wrap_module()" first.'
         module_interface = DDPModuleCheckpointInterface(self._wrapped_module)

--- a/storch/distributed/factory/simple.py
+++ b/storch/distributed/factory/simple.py
@@ -1,0 +1,263 @@
+"""Simple state_dict API.
+
+Some functions are modifications of implementations in the pytorch repo.
+"""
+from __future__ import annotations
+
+from itertools import chain
+from typing import Any, cast
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
+    _get_fqns,
+    _IncompatibleKeys,
+    _state_dict_fn,
+    _StateDictInfo,
+    _unflatten_model_state_dict,
+    _verify_options,
+    _verify_state_dict,
+    gc_context,
+    get_model_state_dict,
+    get_optimizer_state_dict,
+    set_optimizer_state_dict,
+)
+from torch.distributed.checkpoint.stateful import Stateful
+from torch.distributed.fsdp import MixedPrecision
+from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+##########################################################################
+# These functions are likely to be removed after PyTorch fixes this bug. #
+##########################################################################
+
+
+def _load_model_state_dict(
+    model: nn.Module,
+    state_dict: dict[str, Any],
+    info: _StateDictInfo,
+) -> _IncompatibleKeys:
+    """Reimplemented `torch.distributed.checkpoint.state_dict._load_model_state_dict`, supporting buffers."""
+    if not info.handle_model or not state_dict:
+        return _IncompatibleKeys({}, {})
+
+    for key, _ in chain(model.named_parameters(), model.named_buffers()):
+        fqns = _get_fqns(model, key)
+        fqns_with_ddp_prefix = _get_fqns(model, key, skip_ddp_prefix=False)
+        for fqn, fqn_with_ddp_prefix in zip(fqns, fqns_with_ddp_prefix, strict=False):
+            if fqn != fqn_with_ddp_prefix:
+                state_dict[fqn_with_ddp_prefix] = state_dict.pop(fqn)
+
+    with info.fsdp_context():
+        return cast(
+            _IncompatibleKeys,
+            _state_dict_fn(model, 'load_state_dict')(state_dict=state_dict, strict=info.strict),
+        )
+
+
+def _set_model_state_dict(
+    model: nn.Module,
+    model_state_dict: dict[str, Any],
+    *,
+    options: StateDictOptions | None = None,
+) -> _IncompatibleKeys:
+    """Reimplemented `torch.distributed.checkpoint.state_dict.set_model_state_dict`, supporting buffers."""
+    model_state_dict = _unflatten_model_state_dict(model, model_state_dict)
+    with gc_context():
+        info = _verify_options(model, tuple(), optim_only=False, options=options)
+
+        _verify_state_dict(model_state_dict, {}, info)
+        return _load_model_state_dict(model, model_state_dict, info)
+
+
+##########################################################################
+#     ##############################################################     #
+##########################################################################
+
+
+class ModelStateDict(Stateful):
+    """ModelStateDict interface."""
+
+    def __init__(self, model: nn.Module, options: StateDictOptions) -> None:
+        """ModelStateDict.
+
+        This class implements `.state_dict` and `.load_state_dict` functions for parallel models.
+        By using this wrapper, users will be able to save / load model parameters with minimal code changes.
+        Functions in `torch.distributed.checkpoint` are used as backends.
+
+        Args:
+        ----
+            model (nn.Module): The model to get/set the parameters.
+            options (StateDictOptions): StateDictOptions object.
+
+        """
+        self._model = model
+        self._options = options
+
+    def load_state_dict(self, model_state_dict: dict[str, Any]) -> None:
+        """Load state_dict to model.
+
+        Args:
+        ----
+            model_state_dict (dict[str, Any]): The state_dict to load.
+
+        """
+        # This line is a workaround for loading weights on FSDP models before any forward pass.
+        # The state of FSDP is lazily finalized using `_lazy_init` at the first forward call. (From `torch>=2.0.0`)
+        # Calling `.state_dict` also initializes the state, additionally, does not require an input, and implemented in
+        # DDP, FSDP, and nn.Module.
+        # Without this, the below exception is triggered in `_verify_state_dict`.
+        #   `RuntimeError: The model has FSDP modules but no FSDP root module exists.`
+        self._model.state_dict()
+
+        _set_model_state_dict(self._model, model_state_dict, options=self._options)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Get state_dict from model.
+
+        Returns
+        -------
+            dict[str, Any]: The state_dict.
+
+        """
+        return get_model_state_dict(self._model, options=self._options)
+
+
+class OptimStateDict(Stateful):
+    """OptimStateDict interface."""
+
+    def __init__(self, model: nn.Module, optimizer: optim.Optimizer, options: StateDictOptions) -> None:
+        """OptimStateDict interface.
+
+        This class implements `.state_dict` and `.load_state_dict` functions for parallel optimizers.
+        By using this wrapper, users will be able to save / load model parameters with minimal code changes.
+        Functions in `torch.distributed.checkpoint` are used as backends.
+
+        Args:
+        ----
+            model (nn.Module): The model optimized by the optimizers.
+            optimizer (optim.Optimizer): The optimizer,
+            options (StateDictOptions): StateDictOptions object.
+
+        """
+        self.model = model
+        self.optimizer = optimizer
+        self.options = options
+
+    def load_state_dict(self, optim_state_dict: dict[str, Any]) -> None:
+        """Load state_dict to optimizer.
+
+        Args:
+        ----
+            optim_state_dict (dict[str, Any]): The state_dict to load.
+
+        """
+        set_optimizer_state_dict(self.model, self.optimizer, optim_state_dict=optim_state_dict, options=self.options)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Get state_dict from optimizer.
+
+        Returns
+        -------
+            dict[str, Any]: The state_dict.
+
+        """
+        return get_optimizer_state_dict(self.model, self.optimizer, options=self.options)
+
+
+def wrap_module(
+    module: nn.Module,
+    strategy: str | None,
+    mixed_presision: str | bool | None,
+    device_ids: list | None = None,
+    compile: bool = False,
+    **kwargs,
+) -> DDP | FSDP | nn.Module:
+    """Wrap a module according to the `strategy`.
+
+    If `torch.compile` is used on FSDP models, automatically adds `use_orig_params=True`.
+
+    Args:
+    ----
+        module (nn.Module): The module to wrap.
+        strategy (str | None): wrap strategy.
+        mixed_presision (str | bool | None): mixed_precision setting.
+        device_ids (list | None, optional): `device_ids` option for DDP. Default: None.
+        compile (bool, optional): Apply `torch.compile` to model? Default: False.
+        **kwargs: Additional kwargs for parallel wrappers.
+
+    Returns:
+    -------
+        DDP | FSDP | nn.Module: The wrapped module.
+
+    """
+    if strategy is None:
+        return module
+
+    elif strategy == 'ddp':
+        ParallelCls = DDP
+        kwargs['device_ids'] = device_ids
+    elif strategy == 'fsdp':
+        ParallelCls = FSDP
+        if mixed_presision:
+            dtype = torch.float16
+            if isinstance(mixed_presision, str) and mixed_presision in ['bf16', 'bfloat16']:
+                dtype = torch.bfloat16
+            kwargs['mixed_precision'] = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
+        if compile:
+            kwargs['use_orig_params'] = True
+
+    wrapped_module = ParallelCls(module, **kwargs)
+
+    return wrapped_module
+
+
+def create_checkpoint_interface(
+    model: nn.Module,
+    optim: optim.Optimizer,
+    full_state_dict: bool = True,
+    cpu_offload: bool = True,
+    strict: bool = True,
+) -> tuple[ModelStateDict, OptimStateDict]:
+    """Create interfaces for checkpointing.
+
+    This function creates a stateful object that get/set state_dict from model/optimizer wrapped with parallel
+    wrappers without changing any codes between different APIs. Non-parallel models are also acceptable.
+    `optim` argument can be a `None` if the model is not meant for training.
+
+    Args:
+    ----
+        model (nn.Module): The model.
+        optim (optim.Optimizer): The optimizer used to optimize the model.
+        full_state_dict (bool, optional): Return full state_dict for FSDP models. Default: True.
+        cpu_offload (bool, optional): Offload weights to CPU. Default: True.
+        strict (bool, optional): Strict loading. Default: True.
+
+    Returns:
+    -------
+        tuple[ModelStateDict, OptimStateDict]: Created interfaces.
+
+    Examples:
+    --------
+        >>> model = Model(...)
+        >>> model = FSDP(model) # or DDP(model) or as-is.
+        >>> optim = torch.optim.Adam(model.parameters())
+        >>> model_sd, optim_sd = create_checkpoint_interface(model, optim)
+        >>> model_state_dict = model_sd.state_dict() # returns full state_dict
+        >>> model_sd.load_state_dict(model_state_dict) # load full state_dict on FSDP model.
+
+        >>> model_sd, optim_sd = create_checkpoint_interface(model, None) # None as optimizer is allowed.
+        >>> optim_sd is None
+        True
+
+    """
+    model_unwrapped = model._orig_mod if hasattr(model, 'dynamo_ctx') else model
+
+    options = StateDictOptions(full_state_dict=full_state_dict, cpu_offload=cpu_offload, strict=strict)
+
+    model_stateful = ModelStateDict(model_unwrapped, options)
+    optim_stateful = OptimStateDict(model_unwrapped, optim, options) if optim is not None else None
+
+    return model_stateful, optim_stateful

--- a/storch/distributed/utils.py
+++ b/storch/distributed/utils.py
@@ -103,6 +103,7 @@ def gather(
     Returns:
     -------
         torch.Tensor | tuple[torch.Tensor] | tuple[Any]: gathered object.
+
     """
     state = DistributedState()
     if not state.is_distributed:
@@ -152,6 +153,7 @@ def reduce(tensor: torch.Tensor, dst: int | None = None, op: ReduceOp = ReduceOp
     Returns:
     -------
         torch.Tensor: reduced tensor.
+
     """
     state = DistributedState()
 
@@ -183,6 +185,7 @@ def only_on_primary(func: Callable) -> Callable:
     Returns:
     -------
         Callable: wrapped function.
+
     """
 
     @wraps(func)

--- a/storch/hydra_utils.py
+++ b/storch/hydra_utils.py
@@ -24,6 +24,7 @@ def resolve(config: DictConfig | ListConfig) -> DictConfig | ListConfig:
     Returns:
     -------
         DictConfig | ListConfig: resolved config.
+
     """
     OmegaConf.resolve(config)
     return config
@@ -43,6 +44,7 @@ def to_object(config: DictConfig | ListConfig):
     Returns:
     -------
         dict | list: the converted config.
+
     """
     py_obj = OmegaConf.to_object(config)
     return py_obj
@@ -63,6 +65,7 @@ def get_hydra_config(
     Returns:
     -------
         DictConfig: Loaded config.
+
     """
     with initialize_config_dir(config_dir=to_absolute_path(config_dir), version_base=None):
         cfg = compose(config_name, overrides=overrides)
@@ -79,6 +82,7 @@ def save_hydra_config(config: DictConfig, filename: str, resolve: bool = True) -
         config (DictConfig): Config to save.
         filename (str): filename of the saved config.
         resolve (bool, optional): resolve the config before saving. Default: True.
+
     """
     if resolve:
         OmegaConf.resolve(config)

--- a/storch/imageops/opencv.py
+++ b/storch/imageops/opencv.py
@@ -54,6 +54,7 @@ def cv2_load_image(path: str, rgb: bool = True, dtype: np.dtype = np.uint8) -> n
     Returns:
     -------
         np.ndarray: loaded image as numpy array
+
     """
     image = cv2.imread(path, cv2.IMREAD_COLOR)
     if rgb:
@@ -81,6 +82,7 @@ def xdog(
     Returns:
     -------
         np.ndarray: line image.
+
     """
     if image.max() > 1:
         image = image / 255
@@ -113,6 +115,7 @@ def sobel(image: np.ndarray) -> np.ndarray:
     Returns:
     -------
         np.ndarray: line image.
+
     """
     image = cv2.GaussianBlur(image, (3, 3), 0)
     image = cv2.Sobel(image, cv2.CV_8U, 1, 1, ksize=5)
@@ -133,6 +136,7 @@ def slic(image: np.ndarray, num_segments=200, compactness=10) -> np.ndarray:
     Returns:
     -------
         np.ndarray: segmented image.
+
     """
     segments = segmentation.slic(image, n_segments=num_segments, compactness=compactness, start_label=1)
     image = label2rgb(segments, image, kind='avg', bg_label=0)
@@ -155,6 +159,7 @@ def color_hints(image: np.ndarray, num_dots: int = 25, dot_size=3, superpixeled_
     Returns:
     -------
         np.ndarray: color hint image.
+
     """
     h, w = image.shape[:2]
     hint = np.zeros((h, w, 3), dtype=np.uint8)
@@ -185,6 +190,7 @@ def color_palette(image: np.ndarray, num_colors: int = 5, palette_size: int | tu
     Returns:
     -------
         np.ndarray: color palette
+
     """
     if isinstance(palette_size, tuple):
         x, y = palette_size
@@ -221,6 +227,7 @@ def mosaic(image: np.ndarray, ratio: float = 0.1) -> np.ndarray:
     Returns:
     -------
         np.ndarray: image.
+
     """
     small = cv2.resize(image, None, fx=ratio, fy=ratio, interpolation=cv2.INTER_NEAREST)
     image = cv2.resize(small, image.shape[:2][::-1], interpolation=cv2.INTER_NEAREST)
@@ -252,6 +259,7 @@ def mosaic_area(
     Returns:
     -------
         np.ndarray: image.
+
     """
     if box is None:
         box = random_box(image.shape[:2], min_size, max_size, margin)

--- a/storch/imageops/pillow.py
+++ b/storch/imageops/pillow.py
@@ -20,6 +20,7 @@ def pil_configuration(
     ----
         max_image_pixels (int, optional): maximum image pixels. Default: Image.MAX_IMAGE_PIXELS.
         load_truncated_images (bool, optional): load truncated images? Default: False
+
     """
     Image.MAX_IMAGE_PIXELS = max_image_pixels
     ImageFile.LOAD_TRUNCATED_IMAGES = load_truncated_images
@@ -36,6 +37,7 @@ def pil_load_image(path: str, color_mode='RGB') -> Image.Image:
     Returns:
     -------
         Image.Image: The loaded image.
+
     """
     return Image.open(path).convert(color_mode)
 
@@ -53,6 +55,7 @@ def gif_from_files(
         optimize (bool, optional): optimize. Default: False.
         duration (int, optional): duration of each image. Default: 500.
         loop (int, optional): loop mode. Default: infinite loop. Default: 0.
+
     """
     images = [Image.open(str(path)) for path in image_paths]
     images[0].save(filename, save_all=True, append_images=images[1:], optimize=optimize, duration=duration, loop=loop)
@@ -69,6 +72,7 @@ def download(url: str, filename: str | None = None) -> Image.Image:
     Returns:
     -------
         Image.Image: The loaded image.
+
     """
     b = BytesIO(urllib.request.urlopen(url).read())
     image = Image.open(b)

--- a/storch/imageops/torch.py
+++ b/storch/imageops/torch.py
@@ -46,6 +46,7 @@ def torch_load_image(path: str, mode: ImageReadMode = ImageReadMode.RGB):
     Returns:
     -------
         _type_: loaded image.
+
     """
     return read_image(path, mode)
 
@@ -72,6 +73,7 @@ def make_image_grid(*image_tensors, num_images: int | None = None):
         >>> # as long as the sizes are equal except for the batch dimension
         >>> img_tensors = [torch.randn(random.randint(1, 10), 3, 128, 128) for _ in range(24)]
         >>> aligned = make_image_grid(*img_tensors)
+
     """
 
     def _split(x):
@@ -107,6 +109,7 @@ def save_images(
         normalize (bool, optional): torchvision.utils.save_image() argument. Default: True.
         value_range (tuple[float], optional): torchvision.utils.save_image() argument. Default: (-1, 1).
         **kwargs: extra args for make_grid.
+
     """
     images = make_image_grid(*image_tensors, num_images=num_images)
     save_image(images, filename, nrow=nrow, normalize=normalize, value_range=value_range, **kwargs)
@@ -124,6 +127,7 @@ def to_tensor(image: Image.Image, mean: float | tuple = 0.5, std: float | tuple 
     Returns:
     -------
         torch.Tensor: image as tensor.
+
     """
     image = TF.to_tensor(image)
     image = TF.normalize(image, mean, std)
@@ -148,6 +152,7 @@ def tensor2heatmap_cv2(tensor, size, normalize=True, cmap=cv2.COLORMAP_JET) -> t
     Returns:
     -------
         torch.Tensor: heatmap as image.
+
     """
     assert tensor.size(1) == 1 and tensor.ndim == 4, 'Expects 1 channel batched image tensor.'  # noqa: PLR2004
     b, dtype, device = tensor.size(0), tensor.dtype, tensor.device
@@ -976,6 +981,7 @@ def tensor2heatmap(tensor: torch.Tensor, size: tuple[int], normalize: bool = Tru
     Returns:
     -------
         torch.Tensor: heatmap as image.
+
     """
     assert tensor.ndim == 3 or (tensor.ndim == 4 and tensor.size(1) == 1)  # noqa: PLR2004
     if tensor.ndim == 4:  # noqa: PLR2004
@@ -1008,6 +1014,7 @@ def make_mask(image_size: tuple[int], num_boxes: int = 1, min_size: float = 0.1,
     Returns:
     -------
         torch.Tensor: _description_
+
     """
     mask = torch.ones(1, 1, *image_size)
     margin = -int(min(*image_size) * min_size)
@@ -1030,6 +1037,7 @@ def make_masks(image: torch.Tensor, num_boxes: int = 1, min_size: float = 0.1, m
     Returns:
     -------
         torch.Tensor: _description_
+
     """
     B, _, H, W = image.size()
     masks = torch.ones(B, 1, H, W)
@@ -1054,6 +1062,7 @@ def apply_mask(
     Returns:
     -------
         torch.Tensor: _description_
+
     """
     if isinstance(mask_filler, Callable):
         mask_filler = mask_filler(image.size(), device=image.device)
@@ -1075,6 +1084,7 @@ def gaussian_1d(kernel_size: int, sigma: float = 1.0) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 1d-gaussian filter.
+
     """
     x = torch.arange(kernel_size) - kernel_size // 2
     if kernel_size % 2 == 0:
@@ -1094,6 +1104,7 @@ def gaussian_2d(kernel_size: int | tuple[int], sigma: float | tuple[float] = 1.0
     Returns:
     -------
         torch.Tensor: 2d-gaussian filter
+
     """
     kernel_size = to_2tuple(kernel_size)
     sigma = to_2tuple(sigma)
@@ -1127,6 +1138,7 @@ def pascal_1d(kernel_size: int) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 1-d gaussian filter.
+
     """
     kernel = torch.tensor(_pascal_triangle(kernel_size), dtype=torch.float32)
     return kernel / kernel.sum()
@@ -1142,6 +1154,7 @@ def pascal_2d(kernel_size: int | tuple[int]) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 2-d gaussian filter
+
     """
     kernel_size = to_2tuple(kernel_size)
     ksize_x, ksize_y = kernel_size
@@ -1164,6 +1177,7 @@ def laplacian_1d(kernel_size: int) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 1-D Laplacian filter
+
     """
     if kernel_size % 2 != 1:
         raise Exception(f'kernel_size must be odd but got {kernel_size}')
@@ -1182,6 +1196,7 @@ def laplacian_2d(kernel_size: int | tuple[int]) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 2-D Laplacian filter
+
     """
     kernel_size = to_2tuple(kernel_size)
     kernel = torch.ones(kernel_size)
@@ -1200,6 +1215,7 @@ def sobel_2d(kernel_size: int, direction: int = 0) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: 2-D Sobel filter
+
     """
     dx, dy = direction, 1 - direction
     kernel_x, kernel_y = cv2.getDerivKernels(dx, dy, kernel_size)

--- a/storch/imageops/utils.py
+++ b/storch/imageops/utils.py
@@ -16,6 +16,7 @@ def random_box(size: tuple, min_size: float = 0, max_size: float = 1.0, margin: 
     Returns:
     -------
         _type_: _description_
+
     """
     width, height = size
     min_x = min_y = margin

--- a/storch/layers/activation.py
+++ b/storch/layers/activation.py
@@ -26,6 +26,7 @@ def get_activation(name: str, **kwargs) -> nn.Module:
     Returns:
     -------
         nn.Module: The activation function module.
+
     """
     if name == 'relu':
         return nn.ReLU(**kwargs)

--- a/storch/layers/convolution.py
+++ b/storch/layers/convolution.py
@@ -15,6 +15,7 @@ class DepthWiseConv2d(nn.Conv2d):
         dilation (int, optional): Dilation. Default: 1.
         bias (bool, optional): Whether to use bias or not. Default: True.
         padding_mode (str, optional): Padding mode. Default: 'zeros'.
+
     """
 
     def __init__(  # noqa: D107
@@ -48,6 +49,7 @@ class PointWiseConv2d(nn.Conv2d):
         in_channels (int): Channel width of the input feature tensor.
         out_channels (int): Channel width of the resulting tensor.
         bias (bool, optional): Whether to use bias or not. Default: True.
+
     """
 
     def __init__(self, in_channels: int, out_channels: int, bias: bool = True) -> None:  # noqa: D107
@@ -70,6 +72,7 @@ class DepthSepConv2d(nn.Module):
         dilation (int, optional): Dilation. Default: 1.
         bias (bool, optional): Whether to use bias or not. Default: True.
         padding_mode (str, optional): Padding mode. Default: 'zeros'.
+
     """
 
     def __init__(  # noqa: D107

--- a/storch/layers/interpolation.py
+++ b/storch/layers/interpolation.py
@@ -17,6 +17,7 @@ def _make_blur_kernel(filter_size: int) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: The resampling filter.
+
     """
 
     def _pascal_triangle():
@@ -42,6 +43,7 @@ class Blur(nn.Module):
     Args:
     ----
         filter_size (int): Size of the low pass filter. Default: 4
+
     """
 
     def __init__(self, filter_size: int = 4) -> None:  # noqa: D107
@@ -74,6 +76,7 @@ class BlurUpsample(nn.Sequential):
         scale_factor (int, optional): Scale factor for upsampling. Default: 2.
         mode (str, optional): Upsampling mode. Default: 'bilinear'.
         align_corners (bool, optional): Align corners. Default: True.
+
     """
 
     def __init__(  # noqa: D107
@@ -91,6 +94,7 @@ class BlurDownsample(nn.Sequential):
     ----
         filter_size (int, optional): Size of the low pass filter. Default: 4.
         scale (int, optional):  Scale for downsampling. Default: 2.
+
     """
 
     def __init__(self, filter_size: int = 4, scale: int = 2) -> None:  # noqa: D107
@@ -104,6 +108,7 @@ class AABilinearInterp(nn.Module):
     ----
         size (int | None, optional): The output size. Default: None.
         scale_factor (int | None, optional): Scale factor.. Default: None.
+
     """
 
     def __init__(self, size: int | None = None, scale_factor: int | None = None) -> None:  # noqa: D107

--- a/storch/layers/minibatchstddev.py
+++ b/storch/layers/minibatchstddev.py
@@ -10,6 +10,7 @@ class MinibatchStdDev(torch.nn.Module):
     ----
         group_size (int): Size of the group to calculate the statistics.
         num_channels (int, optional): Number of channels to be appended. Defaults to 1.
+
     """
 
     def __init__(self, group_size: int, num_channels: int = 1) -> None:  # noqa: D107

--- a/storch/layers/normalization.py
+++ b/storch/layers/normalization.py
@@ -24,6 +24,7 @@ def get_normalization2d(name: str, channels: int, **kwargs) -> nn.Module:
     Returns:
     -------
         nn.Module: normalization layer module.
+
     """
     if name == 'bn':
         return nn.BatchNorm2d(channels, **kwargs)
@@ -54,6 +55,7 @@ def get_normalization1d(name: str, channels: int, **kwargs) -> nn.Module:
     Returns:
     -------
         nn.Module: normalization layer module.
+
     """
     if name == 'bn':
         return nn.BatchNorm1d(channels, **kwargs)
@@ -118,6 +120,7 @@ class AdaptiveNorm2d(nn.Module):
         channels (int): Input tensor channel width
         affine_layer (nn.Module, optional): nn.Module to transform style vector. Default: nn.Linear.
         biasfree (bool, optional): Bias free. Default: False.
+
     """
 
     def __init__(  # noqa: D107

--- a/storch/layers/squeezeexcitation.py
+++ b/storch/layers/squeezeexcitation.py
@@ -19,6 +19,7 @@ class SpatialSqueezeAndChannelExcitation(nn.Module):
         reduction (int, optional): Reduction factor. Default: 4.
         pool_size (int, optional): Adaptive average pooling size. Default: 1.
         act_name (str, optional): Activation function name. Default: 'relu'.
+
     """
 
     def __init__(self, channels: int, reduction: int = 4, pool_size: int = 1, act_name: str = 'relu') -> None:  # noqa: D107
@@ -44,6 +45,7 @@ class ChannelSqueezeAndSpatialExcitation(nn.Module):
     Args:
     ----
         channels (int): Channel width of the input feature vector.
+
     """
 
     def __init__(self, channels: int) -> None:  # noqa: D107
@@ -64,6 +66,7 @@ class SpatialChannelSqueezeAndExcitation(nn.Module):
         reduction (int, optional): Reduction factor. Default: 4.
         pool_size (int, optional): Adaptive average pooling size. Default: 1.
         act_name (str, optional): Activation function name. Default: 'relu'.
+
     """
 
     def __init__(self, channels: int, reduction: int = 4, pool_size: int = 1, act_name: str = 'relu') -> None:  # noqa: D107

--- a/storch/layers/transformer.py
+++ b/storch/layers/transformer.py
@@ -17,6 +17,7 @@ class MetaformerBlock(nn.Module):
         feedforward (nn.Module): nn.Module which implements a feed forward network.
         norm_layer1 (nn.Module): Normalization layer applied before the attention.
         norm_layer2 (nn.Module): Normalization layer applied before the feed forward network.
+
     """
 
     def __init__(  # noqa: D107

--- a/storch/loss/_base.py
+++ b/storch/loss/_base.py
@@ -4,6 +4,7 @@ class Loss:
     Args:
     ----
         return_all (bool): Return all values used to calculate the loss. Default: False
+
     """
 
     def __init__(self, return_all: bool = False) -> None:

--- a/storch/loss/gan.py
+++ b/storch/loss/gan.py
@@ -21,6 +21,7 @@ class Adversarial(Loss):
         Returns:
         -------
             torch.Tensor: The loss
+
         """
         raise NotImplementedError()
 
@@ -34,6 +35,7 @@ class Adversarial(Loss):
         Returns:
         -------
             torch.Tensor: The loss
+
         """
         raise NotImplementedError()
 
@@ -48,6 +50,7 @@ class Adversarial(Loss):
         Returns:
         -------
             torch.Tensor: The loss
+
         """
         rl = self.real_loss(real_prob)
         fl = self.fake_loss(fake_prob)
@@ -66,6 +69,7 @@ class Adversarial(Loss):
         Returns:
         -------
             torch.Tensor: The loss
+
         """
         return self.real_loss(fake_prob)
 

--- a/storch/loss/penalty.py
+++ b/storch/loss/penalty.py
@@ -23,6 +23,7 @@ def calc_grad(outputs: torch.Tensor, inputs: torch.Tensor, scaler: Optional[Grad
     Returns:
     -------
         torch.Tensor: The gradients of the input.
+
     """
     if isinstance(scaler, GradScaler):
         outputs = scaler.scale(outputs)
@@ -57,6 +58,7 @@ class Penalty(Loss):
         >>> gp_input = gp.prepare_input(real, fake)
         >>> gradients = calc_grad(D(gp_input), gp_input)
         >>> loss = gp.calc(gradients)
+
     """
 
     def __init__(self, return_all: bool = False) -> None:  # noqa: D107
@@ -106,6 +108,7 @@ class gradient_penalty(Penalty):
         Returns:
         -------
             torch.Tensor: The loss
+
         """
         assert center in [1.0, 0.0]
 
@@ -153,6 +156,7 @@ class dragan_penalty(Penalty):
         Returns:
         -------
             torch.Tensor: The loss.
+
         """
         x_hat = self.prepare_input(real)
         d_x_hat = self.filter_output(D(x_hat, *d_aux_input))
@@ -193,6 +197,7 @@ class r1_regularizer(Penalty):
         Returns:
         -------
             torch.Tensor: The loss.
+
         """
         real_loc = self.prepare_input(real)
         d_real_loc = self.filter_output(D(real_loc, *d_aux_input))
@@ -229,6 +234,7 @@ class r2_regularizer(r1_regularizer):
         Returns:
         -------
             torch.Tensor: The loss.
+
         """
         return super().__call__(fake, D, scaler, d_aux_input)
 

--- a/storch/loss/vgg.py
+++ b/storch/loss/vgg.py
@@ -81,6 +81,7 @@ class VGGLoss(Loss):
         p (int, optional): Lp. 1: L1, 2: L2. Default: 2.
         normalized (bool, optional): if the input is normalized or not. Default: True.
         return_all (bool, optional): return all intermediate results Default: False.
+
     """
 
     def __init__(self, device, vgg: int = 16, p: int = 2, normalized: bool = True, return_all: bool = False) -> None:  # noqa: D107

--- a/storch/metrics/best_model.py
+++ b/storch/metrics/best_model.py
@@ -25,6 +25,7 @@ class KeeperCompose:
         >>> best_models.update(val_loss=loss, accuracy=accracy)
         >>> # to load the best state_dict call load with the name of the metric.
         >>> best_models.load('val_loss')
+
     """
 
     def __init__(self, **keepers) -> None:
@@ -33,6 +34,7 @@ class KeeperCompose:
         Args:
         ----
             **keepers: state_dict keepers
+
         """
         assert all(isinstance(keeper, BestStateKeeper) for keeper in keepers.values())
         self.keepers = keepers
@@ -44,6 +46,7 @@ class KeeperCompose:
         ----
             step (int, optional): current training step. Default: None.
             **values: values for updating the keepers.
+
         """
         for name, value in values.items():
             self.keepers[name].update(value, step=step)
@@ -54,6 +57,7 @@ class KeeperCompose:
         Args:
         ----
             name (str): the name of the keeper.
+
         """
         self.keepers[name].load()
 
@@ -80,6 +84,7 @@ class BestStateKeeper:
         >>> val_loss_model.update(loss)
         >>> # to load the best state_dict to the model just call.
         >>> val_loss_model.load()
+
     """
 
     def __init__(
@@ -101,6 +106,7 @@ class BestStateKeeper:
             folder (str): folder to save the states.
             init_abs_value (float): the absolute value to initialize the value. Default: 1e10
             disthelper (None): deprecated.
+
         """
         assert direction in ['min', 'max', 'minimize', 'maximize']
         self.name = name
@@ -133,6 +139,7 @@ class BestStateKeeper:
         Returns
         -------
             bool: True if minimize.
+
         """
         return self.direction == 'min'
 
@@ -142,6 +149,7 @@ class BestStateKeeper:
         Returns
         -------
             bool: True if maximize.
+
         """
         return self.direction == 'max'
 
@@ -156,6 +164,7 @@ class BestStateKeeper:
         Returns:
         -------
             bool: True if updated, else False
+
         """
         if (self.is_minimize() and new_value < self.value) or (self.is_maximize() and new_value > self.value):
             self.value = new_value
@@ -172,6 +181,7 @@ class BestStateKeeper:
         ----
             filename (str): The file name to save to.
             model_state_only (bool, optional): Save only the model state. Default: True.
+
         """
         state_dict = self.state_dict(model_state_only=model_state_only)
         if distutils.is_primary():
@@ -191,6 +201,7 @@ class BestStateKeeper:
         Returns
         -------
             dict: state_dict of this class
+
         """
         model_state = self.model.state_dict()
 
@@ -207,6 +218,7 @@ class BestStateKeeper:
         Args:
         ----
             state_dict (dict): state_dict.
+
         """
         self.direction = state_dict.get('direction')
         self.value = state_dict.get('value')

--- a/storch/metrics/classification.py
+++ b/storch/metrics/classification.py
@@ -34,6 +34,7 @@ def test_classification(
     Returns:
     -------
         dict: classification report as dict if return_dict is True.
+
     """
     if labels is not None:
         labels = np.array(labels)

--- a/storch/metrics/generative.py
+++ b/storch/metrics/generative.py
@@ -55,6 +55,7 @@ def get_features(dataset, model: torch.nn.Module, device: torch.device, progress
     Returns:
     -------
         np.ndarray: the extracted features.
+
     """
     features = []
     for image in tqdm(dataset, disable=not progress):
@@ -79,6 +80,7 @@ def feature_statistics(features: np.ndarray) -> tuple[np.ndarray]:
     -------
         np.ndarray: mean
         np.ndarray: covariance
+
     """
     mean = np.mean(features, axis=0)
     sigma = np.cov(features, rowvar=False)
@@ -101,6 +103,7 @@ def frechet_distance(feature1: np.ndarray, feature2: np.ndarray, eps: float = 1e
     Returns:
     -------
         float: fid score
+
     """
     mu1, sigma1 = feature_statistics(feature1)
     mu2, sigma2 = feature_statistics(feature2)
@@ -151,6 +154,7 @@ def kernel_distance(feature1: np.ndarray, feature2: np.ndarray, num_subsets=100,
     Returns:
     -------
         float: kid score
+
     """
     n = feature1.shape[1]
     m = min(feature1.shape[0], feature2.shape[0], max_subset_size)
@@ -179,6 +183,7 @@ def pairwise_distance(feature1: np.ndarray, feature2: np.ndarray = None) -> np.n
     Returns:
     -------
         np.ndarray: distances.
+
     """
     if feature2 is None:
         feature2 = feature1
@@ -197,6 +202,7 @@ def nearest_neighbour_distances(features: np.ndarray, nearest_k: int) -> np.ndar
     Returns:
     -------
         np.ndarray: Distances to kth nearest neighbours.
+
     """
     distances = pairwise_distance(features)
     indices = np.argpartition(distances, nearest_k + 1, axis=-1)[..., : nearest_k + 1]
@@ -216,6 +222,7 @@ def precision(real_nearest_neighbour_distances: np.ndarray, distance_real_fake: 
     Returns:
     -------
         float: precision score
+
     """
     return (distance_real_fake < np.expand_dims(real_nearest_neighbour_distances, axis=1)).any(axis=0).mean()
 
@@ -231,6 +238,7 @@ def recall(fake_nearest_neighbour_distances: np.ndarray, distance_real_fake: np.
     Returns:
     -------
         float: recall score
+
     """
     return (distance_real_fake < np.expand_dims(fake_nearest_neighbour_distances, axis=0)).any(axis=1).mean()
 
@@ -247,6 +255,7 @@ def density(real_nearest_neighbour_distances: np.ndarray, distance_real_fake: np
     Returns:
     -------
         float: density
+
     """
     return (1.0 / float(nearest_k)) * (
         distance_real_fake < np.expand_dims(real_nearest_neighbour_distances, axis=1)
@@ -264,6 +273,7 @@ def coverage(real_nearest_neighbour_distances: np.ndarray, distance_real_fake: n
     Returns:
     -------
         float: coverage score
+
     """
     return (distance_real_fake.min(axis=1) < real_nearest_neighbour_distances).mean()
 
@@ -330,6 +340,7 @@ def calc_metrics(
     Returns:
     -------
         dict: dictionary containing the metrics
+
     """
     if metric_flags is None:
         metric_flags = MetricFlags()

--- a/storch/metrics/image.py
+++ b/storch/metrics/image.py
@@ -28,6 +28,7 @@ def psnr(
     Returns:
     -------
         torch.Tensor: calculated PSNR score
+
     """
     mse_error = (input.double() - target.double()).square().mean(dim=(1, 2, 3), keepdim=True)
     psnr = 10.0 * torch.log10(max_val**2 / mse_error)
@@ -60,6 +61,7 @@ def ssim(
     Returns:
     -------
         torch.Tensor: _description_
+
     """
     B, C, device = input.size(0), input.size(1), input.device
     kernel_size, sigma = to_2tuple(kernel_size), to_2tuple(sigma)

--- a/storch/metrics/utils/__init__.py
+++ b/storch/metrics/utils/__init__.py
@@ -14,6 +14,7 @@ def reduce_dimension(tensor: torch.Tensor, mode: str) -> torch.Tensor:
     Returns:
     -------
         torch.Tensor: reduced loss.
+
     """
     if mode == 'sum':
         return tensor.flatten(1).sum()

--- a/storch/metrics/utils/cache.py
+++ b/storch/metrics/utils/cache.py
@@ -25,6 +25,7 @@ class FeatureCache:
         Returns:
         -------
             np.ndarray | None: cached feature. None when not registered.
+
         """
         return cls._cache.get(cls.make_key(folder, model, num_images), None)
 
@@ -39,6 +40,7 @@ class FeatureCache:
             num_images (int): number of images.
             features (np.ndarray): the extracted features
             force (bool, optional): force to register features exven if already exists. Defaults to False.
+
         """
         key = cls.make_key(folder, model, num_images)
         if force or key not in cls._cache:
@@ -57,6 +59,7 @@ class FeatureCache:
         Returns:
         -------
             tuple[str, str, int]: key.
+
         """
         key = tuple(folder, model, num_images)
         assert all(isinstance(element, Hashable) for element in key)

--- a/storch/metrics/utils/dataset.py
+++ b/storch/metrics/utils/dataset.py
@@ -40,6 +40,7 @@ def build_dataset(
     Returns:
     -------
         DataLoader: dataset
+
     """
     dataset = CleanResizeDataset(
         root_dir, synthesized_size, feature_extractor_input_size, synthetic, num_images, filter_fn
@@ -72,6 +73,7 @@ class CleanResizeDataset(Dataset):
             synthetic (bool, optional): Is fake set. Default: False.
             num_images (int, optional): Number of images. Default: None.
             filter_fn (Callable | None, optional): Callable to filter image paths. Default: None.
+
         """
         super().__init__()
         self.image_paths = _collect_image_paths(root_dir, filter_fn)
@@ -121,6 +123,7 @@ class CleanResizeDataset(Dataset):
         Returns:
         -------
             Image.Image: resized image.
+
         """
         image_splits = image.split()
         new_image = []

--- a/storch/metrics/utils/download.py
+++ b/storch/metrics/utils/download.py
@@ -19,6 +19,7 @@ def download_url(url: str, filename: str, folder: str = './.cache/storch/metrics
     Returns:
     -------
         str: the path to the downloaded file.
+
     """
     folder = Path(folder)
     ckpt_path = folder / filename

--- a/storch/metrics/utils/inceptionv3.py
+++ b/storch/metrics/utils/inceptionv3.py
@@ -30,6 +30,7 @@ class InceptionV3JIT(nn.Module):
             feature_dims (int, optional): deprecated.
             weight_folder (str, optional): Folder to save the weights. Default: './.cache/storch/metrics'.
             filename (str, optional): filename. Default: 'jit-inception-2015-12-05.torch'.
+
         """
         super().__init__()
         self.ckpt_path = download_url(JIT_INCEPTION_URL, filename, weight_folder)
@@ -60,6 +61,7 @@ class InceptionV3(nn.Module):
             feature_dims (int, optional): Number of output feature dimension. Default: 2048.
             weight_folder (str, optional): Folder to save the weights. Default: './.cache/storch/metrics'.
             filename (str, optional): File to save the weights. Default: 'inception-2015-12-05.torch'.
+
         """
         super().__init__()
         feature_dim2block_index = {64: 0, 192: 1, 768: 2, 2048: 3}

--- a/storch/metrics/utils/resnet.py
+++ b/storch/metrics/utils/resnet.py
@@ -21,6 +21,7 @@ class _ResNet(nn.Module):
             feature_dims (int, optional): deprecated.
             weight_folder (str, optional): Folder to save the weights. Default: './.cache/storch/metrics'.
             filename (str, optional): filename. Default: 'jit-inception-2015-12-05.torch'.
+
         """
         super().__init__()
         feature_dim2block_index = {256: 0, 512: 1, 1024: 2, 2048: 3}
@@ -83,6 +84,7 @@ class ResNetIN(_ResNet):
         Returns:
         -------
             str, nn.Module: path to the weights and the resnet model.
+
         """
         ckpt_path = None
         if is_multi_weight_api_available():

--- a/storch/profiler.py
+++ b/storch/profiler.py
@@ -33,6 +33,7 @@ def get_tb_profile(
     Returns:
     -------
         profile: profiler.
+
     """
     if activities is None:
         activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
@@ -59,6 +60,7 @@ def profiled_function(func: Callable) -> Callable:
     Returns:
     -------
         Callable: The wrapped function.
+
     """
 
     @wraps(func)

--- a/storch/project/utils.py
+++ b/storch/project/utils.py
@@ -66,6 +66,7 @@ def init_run(
         >>> $ python3 train.py
         >>> # resume from a checkpoint
         >>> $ python3 train.py ./path/to/checkpoint/config.yaml
+
     """
     if child_folders is None:
         child_folders = {}

--- a/storch/scheduler.py
+++ b/storch/scheduler.py
@@ -30,6 +30,7 @@ def get_constant_schedule(num_warmup_steps: int | None = None) -> Callable:
     Returns:
     -------
         Callable: always returns 1.0
+
     """
     if num_warmup_steps is None:
 
@@ -57,6 +58,7 @@ def get_multistep_schedule(milestones: list, num_warmup_steps: int | None = None
     Returns:
     -------
         Callable: function for LambdaLR
+
     """
     milestones = np.asarray(milestones)
     if num_warmup_steps is None:
@@ -86,6 +88,7 @@ def get_linear_schedule(num_training_steps: int, num_warmup_steps: int) -> Calla
     Returns:
     -------
         Callable: function for LambdaLR
+
     """
     if num_warmup_steps is None:
 
@@ -117,6 +120,7 @@ def get_polynomial_decay_schedule(
     Returns:
     -------
         Callable: _description_
+
     """
     if num_warmup_steps is None:
 
@@ -158,6 +162,7 @@ def get_cosine_schedule(
     Returns:
     -------
         Callable: function for LambdaLR
+
     """
     if num_warmup_steps is None:
 
@@ -212,6 +217,7 @@ def build_scheduler(
     Returns:
     -------
         LambdaLR: learning rate scheduler.
+
     """
     num_training_steps = num_training_steps * num_iter_per_step
     num_warmup_steps = num_warmup_steps * num_iter_per_step if num_warmup_steps is not None else None

--- a/storch/status.py
+++ b/storch/status.py
@@ -44,6 +44,7 @@ class Collector:
         ----
             name (str): Key for the value. This name will be used at .add_scalar() of SummaryWriter.
             value (float | torch.Tensor): The value to collect.
+
         """
         if value is None:
             return
@@ -67,6 +68,7 @@ class Collector:
         Args:
         ----
             step (dict[str, Any]): dict of values to report.
+
         """
         for name, value in step.items():
             self.report(name, value)
@@ -81,6 +83,7 @@ class Collector:
         Returns:
         -------
             float: mean of the collected values.
+
         """
         if name not in self._deltas or self._deltas[name][0] == 0:
             return float('inf')
@@ -92,6 +95,7 @@ class Collector:
         Returns
         -------
             dict[str, float]: dict of mean of all reported values.
+
         """
         output = {}
         for name in self._deltas:
@@ -122,6 +126,7 @@ class Status:
         >>>         'Loss/CE/val': torch.rand(1),
         >>>         'Metrics/accuracy/val': torch.rand(1),
         >>>     })
+
     """
 
     def __init__(
@@ -164,6 +169,7 @@ class Status:
                 - key: The name used to identify the value.
                 - value: The value.
                 Default: '{key}: {value: 10.5f}'.
+
         """
         self._max_iters = max_iters
         self._batches_done = 0
@@ -223,6 +229,7 @@ class Status:
         Args:
         ----
             quiet (bool, optional): do not log run stats. Default: None.
+
         """
         if self._wandb_run is not None:
             wandb.finish(quiet=quiet)
@@ -237,6 +244,7 @@ class Status:
         Returns:
         -------
             str: The formated kilo batches.
+
         """
         kbatches = self._batches_done / 1000
         return format.format(kbatches=kbatches)
@@ -250,6 +258,7 @@ class Status:
         ----
             message (str): The message to log.
             level (str, optional): log level. Default: 'info'.
+
         """
         getattr(self._logger, level)(message)
 
@@ -271,6 +280,7 @@ class Status:
                 Used to display the default values. Default: None.
             filename (str, optional): A filename. if given the arguments will be saved to this file.
                 Default: None.
+
         """
         message = '------------------------- Options -----------------------\n'
         for k, v in sorted(vars(args).items()):
@@ -292,6 +302,7 @@ class Status:
         Args:
         ----
             config (DictConfig): The config to log.
+
         """
         yamlconfig = OmegaConf.to_yaml(config)
         self.log(f'Config:\n{yamlconfig}')
@@ -302,6 +313,7 @@ class Status:
         Args:
         ----
             dataloader (DataLoader): The DataLoader object to log.
+
         """
         dataset = dataloader.dataset
         sampler = dataloader.sampler
@@ -336,6 +348,7 @@ class Status:
         Args:
         ----
             optimizer (Optimizer): The optimizer object to log.
+
         """
         self.log(f'Optimizer:\n{optimizer}')
 
@@ -350,6 +363,7 @@ class Status:
         Args:
         ----
             model (torch.nn.Module): The module to log.
+
         """
         self.log(f'Architecture: {model.__class__.__name__}:\n{model}')
 
@@ -377,6 +391,7 @@ class Status:
             >>> status.log_gpu_memory('backward', [0, 100])
             >>> optimizer.step()
             >>> status.log_gpu_memory('step', [0, 100])
+
         """
 
         def hook():
@@ -416,6 +431,7 @@ class Status:
             batch_size_per_proc (int): batch size per process.
             gradient_accumulation_steps (int): gradient accumulation steps.
             world_size (int): world size.
+
         """
         real_batch_size = batch_size_per_proc * gradient_accumulation_steps * world_size
         if real_batch_size == batch_size_per_proc:
@@ -531,6 +547,7 @@ class Status:
             value_range (tuple, optional): argument for make_grid(). Default: (-1, 1).
             nrow (int, optional): argument for make_grid(). Default: 8.
             **mkgridkwargs: other keyword arguments for make_grid().
+
         """
         images = make_grid(image_tensor, normalize=normalize, value_range=value_range, nrow=nrow, **mkgridkwargs)
         self._tbwriter.add_images(tag, images, self.batches_done)
@@ -547,6 +564,7 @@ class Status:
         Args:
         ----
             enabled (bool, optional): Boolean to enable/disable profiling. Default: True.
+
         """
         if enabled:
             self._profiler = get_tb_profile(self._tb_folder)
@@ -572,6 +590,7 @@ class Status:
             >>>     # this will stop the timer until exiting the with statement.
             >>>     with status.stop_timer():
             >>>         validate(...)
+
         """
         stop_start = time.time()
         yield
@@ -598,6 +617,7 @@ class Status:
         Args:
         ----
             state_dict (dict): a dictionary made by status.state_dict().
+
         """
         # load
         self._collector = state_dict['collector']
@@ -610,6 +630,7 @@ class Status:
         Returns
         -------
             dict: Dict containing the states.
+
         """
         return dict(collector=self._collector, batches_done=self.batches_done, steptimes=self._steptimes)
 

--- a/storch/torchops.py
+++ b/storch/torchops.py
@@ -69,6 +69,7 @@ def auto_get_device(force_cpu: bool = False, no_gpu_msg_type='warn') -> torch.de
     Returns:
     -------
         torch.device: Device.
+
     """
     if torch.cuda.is_available() or not force_cpu:
         return torch.device('cuda')
@@ -93,6 +94,7 @@ def freeze(model: nn.Module) -> None:
     Args:
     ----
         model (nn.Module): The module to freeze.
+
     """
     model.eval()
     model.requires_grad_(False)
@@ -107,6 +109,7 @@ def unfreeze(model: nn.Module) -> None:
     Args:
     ----
         model (nn.Module): The module to unfreeze.
+
     """
     model.requires_grad_(True)
     model.train()
@@ -131,6 +134,7 @@ def update_ema(
         decay (float, optional):  Decay for exponential modving average. Default: 0.999.
         copy_buffers (bool, optional): If True, also copy buffers inside the model. Default: False.
         force_cpu (bool, optional): If True, process on cpu. Expects the model_ema to be on CPU. Default: False.
+
     """
     if force_cpu:
         org_device = next(model.parameters()).device
@@ -171,6 +175,7 @@ def set_seeds(
     -------
         Callable: Function for DataLoader's worker_init_fn option.
         torch.Generator: torch.Generator for DataLoader's generator option.
+
     """
     random.seed(seed)
     np.random.seed(seed)
@@ -203,6 +208,7 @@ def shuffle_batch(
     -------
         torch.Tensor: The shuffled tensor.
         torch.Tensor: The permutation. Only when return_permutation==True.
+
     """
     permutation = torch.randperm(batch.size(0))
     shuffled = batch[permutation]
@@ -218,6 +224,7 @@ def assert_shape(tensor: torch.Tensor, shape: torch.Size | tuple | list) -> None
     ----
         tensor (torch.Tensor): tensor to check the shape of
         shape (torch.Size | tuple | list): expected shape of tensor. -1 or None for arbitrary size.
+
     """
     assert tensor.ndim == len(shape), f'Wrong number of dimensions: got {tensor.ndim} expected {len(shape)}'
     for i, (size, exp_size) in enumerate(zip(tensor.size(), shape, strict=False)):
@@ -244,6 +251,7 @@ def print_module_summary(
         max_nesting (int, optional): Max nested modules to print. Default: 3.
         skip_redundant (bool, optional): Filter out redundant entries. Default: True.
         print_fn (Callable, optional): Function for printing the summary. Default: print.
+
     """
     assert isinstance(module, torch.nn.Module)
     assert not isinstance(module, torch.jit.ScriptModule)
@@ -330,6 +338,7 @@ def convert_outputs_to_fp32(func: Callable) -> Callable:
     Returns:
     -------
         Callable: the wrapped function.
+
     """
 
     def convert_to_fp32(tensor: torch.Tensor):
@@ -356,6 +365,7 @@ def get_grad_scaler(enabled=True, is_fsdp=False, disable_with_none=False) -> Gra
     Returns:
     -------
         GradScaler | None: gradient scaler class
+
     """
     scaler = GradScaler(enabled=enabled) if not is_fsdp else ShardedGradScaler(enabled=enabled)
     if not enabled and disable_with_none:
@@ -371,6 +381,7 @@ def local_seed_builtin(seed: int, enabled: bool = True) -> None:
     ----
         seed (int): Seed.
         enabled (bool, optional): Enable local seed if True. Default: True.
+
     """
     if enabled:
         random_state = random.getstate()
@@ -388,6 +399,7 @@ def local_seed_numpy(seed: int, enabled: bool = True) -> None:
     ----
         seed (int): Seed.
         enabled (bool, optional): Enable local seed if True. Default: True.
+
     """
     if enabled:
         random_state = np.random.get_state()
@@ -405,6 +417,7 @@ def local_seed_torch(seed: int, enabled: bool = True) -> None:
     ----
         seed (int): Seed.
         enabled (bool, optional): Enable local seed if True. Default: True.
+
     """
     if enabled:
         random_state = torch.get_rng_state()
@@ -425,6 +438,7 @@ def local_seed(seed: int, enabled: bool = True, builtin: bool = True, numpy: boo
         builtin (bool, optional): Independent flag for builtin random. Ignored when enabled=False. Default: True.
         numpy (bool, optional): Independent flag for numpy. Ignored when enabled=False. Default: True.
         torch (bool, optional): Independent flag for torch. Ignored when enabled=False. Default: True.
+
     """
     if not enabled:
         builtin = numpy = torch = False
@@ -449,6 +463,7 @@ def fixed_random(seed: int, enabled: bool = True) -> Callable:
         >>> @fixed_random(3407)
         ... def test():
         ...     pass
+
     """
 
     def decorator(func):

--- a/storch/transforms/converters.py
+++ b/storch/transforms/converters.py
@@ -15,6 +15,7 @@ def pil_to_numpy(image: Image.Image, like_to_tensor: bool = True) -> np.ndarray:
     Returns:
     -------
         np.ndarray: Converted image.
+
     """
     assert isinstance(image, Image.Image)
     image = np.asarray(image)

--- a/storch/transforms/degradations.py
+++ b/storch/transforms/degradations.py
@@ -32,6 +32,7 @@ def sigma_matrix2(sig_x: float, sig_y: float, theta: float) -> np.ndarray:
     Returns:
     -------
         ndarray: Rotated sigma matrix.
+
     """
     d_matrix = np.array([[sig_x**2, 0], [0, sig_y**2]])
     u_matrix = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
@@ -50,6 +51,7 @@ def mesh_grid(kernel_size: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         ndarray: with the shape (kernel_size, kernel_size, 2)
         ndarray: with the shape (kernel_size, kernel_size)
         ndarray: with the shape (kernel_size, kernel_size)
+
     """
     ax = np.arange(-kernel_size // 2 + 1.0, kernel_size // 2 + 1.0)
     xx, yy = np.meshgrid(ax, ax)
@@ -71,6 +73,7 @@ def pdf2(sigma_matrix: np.ndarray, grid: np.ndarray) -> np.ndarray:
     Returns:
     -------
         ndarrray: un-normalized kernel.
+
     """
     inverse_sigma = np.linalg.inv(sigma_matrix)
     kernel = np.exp(-0.5 * np.sum(np.dot(grid, inverse_sigma) * grid, 2))
@@ -115,6 +118,7 @@ def bivariate_Gaussian(
     Returns:
     -------
         ndarray: normalized kernel.
+
     """
     if grid is None:
         grid, _, _ = mesh_grid(kernel_size)
@@ -154,6 +158,7 @@ def bivariate_generalized_Gaussian(
     Returns:
     -------
         ndarray:
+
     """
     if grid is None:
         grid, _, _ = mesh_grid(kernel_size)
@@ -195,6 +200,7 @@ def bivariate_plateau(
     Returns:
     -------
         ndarray:
+
     """
     if grid is None:
         grid, _, _ = mesh_grid(kernel_size)
@@ -233,6 +239,7 @@ def random_bivariate_Gaussian(
     Returns:
     -------
         ndarray:
+
     """
     assert kernel_size % 2 == 1, 'Kernel size must be an odd number.'
     assert sigma_x_range[0] < sigma_x_range[1], 'Wrong sigma_x_range.'
@@ -283,6 +290,7 @@ def random_bivariate_generalized_Gaussian(
     Returns:
     -------
         ndarray:
+
     """
     assert kernel_size % 2 == 1, 'Kernel size must be an odd number.'
     assert sigma_x_range[0] < sigma_x_range[1], 'Wrong sigma_x_range.'
@@ -339,6 +347,7 @@ def random_bivariate_plateau(
     Returns:
     -------
         ndarray:
+
     """
     assert kernel_size % 2 == 1, 'Kernel size must be an odd number.'
     assert sigma_x_range[0] < sigma_x_range[1], 'Wrong sigma_x_range.'
@@ -400,6 +409,7 @@ def random_mixed_kernels(
     Returns:
     -------
         ndarray:
+
     """
     kernel_type = np.random.choice(kernel_list, p=kernel_prob)
     if kernel_type == 'iso':
@@ -461,6 +471,7 @@ def circular_lowpass_kernel(cutoff: float, kernel_size: int, pad_to: int = 0) ->
     Returns:
     -------
         ndarray:
+
     """
     assert kernel_size % 2 == 1, 'Kernel size must be an odd number.'
     kernel = np.fromfunction(
@@ -492,6 +503,7 @@ def _clip_rounds(image: np.ndarray, clip: bool = True, rounds: bool = False) -> 
     Returns:
     -------
         ndarray:
+
     """
     if clip and rounds:
         image = np.clip((image * 255.0).round(), 0, 255) / 255.0
@@ -514,6 +526,7 @@ def generate_gaussian_noise(size: tuple[float], sigma: float = 10.0, gray_noise:
     Returns:
     -------
         ndarray:
+
     """
     if gray_noise:
         noise = np.random.randn(*size[:2])
@@ -541,6 +554,7 @@ def add_gaussian_noise(
     Returns:
     -------
         ndarray
+
     """
     noise = generate_gaussian_noise(image.shape, sigma, gray_noise)
     image = image + noise
@@ -568,6 +582,7 @@ def random_gaussian_noise(
     Returns:
     -------
         ndarray:
+
     """
     sigma = np.random.uniform(*sigma_range)
     gray_noise = np.random.rand() < gray_prob
@@ -593,6 +608,7 @@ def generate_poisson_noise(
     Returns:
     -------
         np.ndarray:
+
     """
     if gray_noise:
         image = cv2.cvtColor(image, cv2_cvtcolor_mode)
@@ -629,6 +645,7 @@ def add_poisson_noise(
     Returns:
     -------
         np.ndarray:
+
     """
     noise = generate_poisson_noise(image, scale, gray_noise, cv2_cvtcolor_mode)
     image = image + noise
@@ -658,6 +675,7 @@ def random_poisson_noise(
     Returns:
     -------
         np.ndarray:
+
     """
     scale = np.random.uniform(*scale_range)
     gray_noise = np.random.rand() < gray_prob
@@ -679,6 +697,7 @@ def add_jpg_compression(image: np.ndarray, quality: float = 90) -> np.ndarray:
     Returns:
     -------
         ndarray:
+
     """
     image = np.clip(image, 0, 1)
     encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), round(quality)]
@@ -699,6 +718,7 @@ def random_jpg_compression(image: np.ndarray, quality_range: tuple[float] = (90,
     Returns:
     -------
         ndarray:
+
     """
     quality = np.random.uniform(*quality_range)
     return add_jpg_compression(image, quality)

--- a/storch/transforms/resize_right.py
+++ b/storch/transforms/resize_right.py
@@ -49,6 +49,7 @@ def resize(
     Returns:
     -------
         (np.ndarray | torch.Tensor): resized image
+
     """
     if isinstance(interp_method, str):
         interp_method = INTERP_METHODS[interp_method]

--- a/storch/transforms/timm_mixup.py
+++ b/storch/transforms/timm_mixup.py
@@ -23,6 +23,7 @@ def rand_bbox(image_shape, lam, margin=0.0, count=None):
         lam (float): Cutmix lambda value
         margin (float): Percentage of bbox dimension to enforce as margin (reduce amount of box outside image)
         count (int): Number of bbox to generate
+
     """
     ratio = np.sqrt(1 - lam)
     img_h, img_w = image_shape[-2:]
@@ -49,6 +50,7 @@ def rand_bbox_minmax(image_shape, minmax, count=None):
         image_shape (tuple): Image shape as tuple
         minmax (tuple or list): Min and max bbox ratios (as percent of image size)
         count (int): Number of bbox to generate
+
     """
     assert len(minmax) == 2
     img_h, img_w = image_shape[-2:]
@@ -97,6 +99,7 @@ class Mixup(torch.nn.Module):
             switch_prob (float, optional): Probability to switch to CutMix. Default: 0.5.
             mode (str, optional): Apply Mixup {batch,element}-wise. Default: 'batch'.
             correct_lambda (bool, optional): correct lambda. Default: True.
+
         """
         super().__init__()
         self.mixup_alpha = mixup_alpha
@@ -213,6 +216,7 @@ class Mixup(torch.nn.Module):
         Returns:
         -------
             torch.Tensor: the loss
+
         """
         ce_loss_a = F.cross_entropy(logits, targets, reduction='none', label_smoothing=label_smoothing) * lambdas
         ce_loss_b = F.cross_entropy(logits, targets.flip(0), reduction='none', label_smoothing=label_smoothing) * (

--- a/storch/transforms/transforms.py
+++ b/storch/transforms/transforms.py
@@ -24,6 +24,7 @@ class PILToNumpy(nn.Module):
         Args:
         ----
             like_to_tensor (bool, optional): Default: True.
+
         """
         super().__init__()
         self.like_to_tensor = like_to_tensor
@@ -58,6 +59,7 @@ class RandomMixedGaussianBlur(nn.Module):
             betag_range (tuple, optional): Default: [0.5, 8].
             betap_range (tuple, optional): Default: [0.5, 8].
             noise_range (tuple | None, optional): Default: None.
+
         """
         super().__init__()
         self.kernel_list = kernel_list
@@ -97,6 +99,7 @@ class RandomGaussianNoise(nn.Module):
         ----
             sigma_range (tuple, optional): Default: [0.0, 10.0].
             gray_prob (float, optional): Default: 0.0.
+
         """
         super().__init__()
         self.sigma_range = sigma_range
@@ -117,6 +120,7 @@ class RandomPoissonNoise(nn.Module):
         ----
             scale_range (tuple, optional): Default: [0.0, 1.0].
             gray_prob (float, optional): Default: 0.0.
+
         """
         super().__init__()
         self.scale_range = scale_range
@@ -136,6 +140,7 @@ class RandomJPEGCompression(nn.Module):
         Args:
         ----
             quality_range (tuple, optional): Default: [90, 100].
+
         """
         super().__init__()
         self.quality_range = quality_range
@@ -156,6 +161,7 @@ class ResizeRight(nn.Module):
             size (_type_): size to resize.
             interp_method (str, optional): Default: 'cubic'.
             antialias (bool, optional): Default: True.
+
         """
         super().__init__()
         self.size = size

--- a/storch/transforms/v2.py
+++ b/storch/transforms/v2.py
@@ -37,6 +37,7 @@ def to_image(image: Image.Image, dtype: torch.dtype = torch.float) -> tv_tensors
     Returns:
     -------
         tv_tensors.Image: converted image.
+
     """
     image = F.to_image(image)  # PIL -> torch.Tensor (dtype: uint8)
     image = F.to_dtype(image, dtype=dtype)
@@ -53,6 +54,7 @@ def to_mask(mask: Image.Image) -> tv_tensors.Mask:
     Returns:
     -------
         tv_tensors.Mask: mask.
+
     """
     return tv_tensors.Mask(mask)
 
@@ -112,6 +114,7 @@ class RandomMixedGaussianBlur(Transform):
             betag_range (tuple, optional): Default: [0.5, 8].
             betap_range (tuple, optional): Default: [0.5, 8].
             noise_range (tuple | None, optional): Default: None.
+
         """
         super().__init__()
         self.kernel_list = kernel_list
@@ -153,6 +156,7 @@ class RandomGaussianNoise(Transform):
         ----
             sigma_range (tuple, optional): Default: [0.0, 10.0].
             gray_prob (float, optional): Default: 0.0.
+
         """
         super().__init__()
         self.sigma_range = sigma_range
@@ -175,6 +179,7 @@ class RandomPoissonNoise(Transform):
         ----
             scale_range (tuple, optional): Default: [0.0, 1.0].
             gray_prob (float, optional): Default: 0.0.
+
         """
         super().__init__()
         self.scale_range = scale_range
@@ -196,6 +201,7 @@ class RandomJPEGCompression(Transform):
         Args:
         ----
             quality_range (tuple, optional): Default: [90, 100].
+
         """
         super().__init__()
         self.quality_range = quality_range
@@ -218,6 +224,7 @@ class ResizeRight(Transform):
             size (_type_): size to resize.
             interp_method (str, optional): Default: 'cubic'.
             antialias (bool, optional): Default: True.
+
         """
         super().__init__()
         self.size = size

--- a/storch/utils/version.py
+++ b/storch/utils/version.py
@@ -22,6 +22,7 @@ def _is_version_geq(current, minimum: str) -> bool:
     Returns:
     -------
         bool: result.
+
     """
     if isinstance(minimum, str):
         minimum = parse_version(minimum)
@@ -38,6 +39,7 @@ def is_python_version_geq(minimum) -> bool:
     Returns:
     -------
         bool: result.
+
     """
     return _is_version_geq(_PYTHON_VERSION, minimum)
 
@@ -52,6 +54,7 @@ def is_torch_version_geq(minimum) -> bool:
     Returns:
     -------
         bool: result.
+
     """
     return _is_version_geq(_PYTORCH_VERSION, minimum)
 
@@ -66,6 +69,7 @@ def is_torchvision_version_geq(minimum: str) -> bool:
     Returns:
     -------
         bool: result.
+
     """
     return _is_version_geq(_TORCHVISION_VERSION, minimum)
 
@@ -76,6 +80,7 @@ def is_native_amp_available() -> bool:
     Returns
     -------
         bool: result.
+
     """
     return is_torch_version_geq('1.6.0')
 
@@ -86,6 +91,7 @@ def is_multi_weight_api_available() -> bool:
     Returns
     -------
         bool: result.
+
     """
     return is_torchvision_version_geq('0.13.0')
 
@@ -96,6 +102,7 @@ def is_compiler_available() -> bool:
     Returns
     -------
         bool: result.
+
     """
     return is_torch_version_geq('2.0.0')
 
@@ -108,5 +115,17 @@ def is_v2_transforms_available() -> bool:
     Returns
     -------
         bool: result.
+
     """
     return is_torchvision_version_geq('0.16.0')
+
+
+def is_dist_state_dict_available() -> bool:
+    """Is distributed get / set state_dict API available.
+
+    Returns
+    -------
+        bool: result.
+
+    """
+    return is_torch_version_geq('2.2.0')

--- a/storch/version.py
+++ b/storch/version.py
@@ -1,2 +1,2 @@
 """Version."""
-__version__ = '0.5.6'
+__version__ = '0.5.7'

--- a/storch/visualization/plt_utils.py
+++ b/storch/visualization/plt_utils.py
@@ -28,6 +28,7 @@ def plt_subplots(nrows: int = 1, ncols: int = 1, format_axes: bool = True, filen
     ------
         Figure: matplotlib.figure.Figure object made by plt.subplot().
         Axes|list[Axes]|list[list[Axes]]: list or object of matplotlib.axes.Axes made by plt.subplot().
+
     """
     fig, axes = plt.subplots(nrows=nrows, ncols=ncols, **kwargs)
     if format_axes:
@@ -104,6 +105,7 @@ def ax_setter(  # noqa: PLR0915
         invert_yaxis (bool, optional): invert y axis. Default: False.
         xscale (str, optional): scale of x axis. Default: None.
         yscale (str, optional): scale of y axis. Default: None.
+
     """
     if title is not None:
         ax.set_title(title)

--- a/storch/wandb.py
+++ b/storch/wandb.py
@@ -66,6 +66,7 @@ def init(
     Returns:
     -------
         Run: a `wandb.Run` object.
+
     """
     run = None
     if is_wandb_available() and os.getenv(ENV_WANDB_API_KEY, '') != '':
@@ -93,5 +94,6 @@ def finish(quiet: bool | None = None) -> None:
     Args:
     ----
         quiet (bool | None): Do not print summary. Default: None.
+
     """
     wandb.finish(quiet=quiet)


### PR DESCRIPTION
# WHAT

Fixes #116

## Changes
NOTE: All changes requires `torch>=2.2.0`. This is automatically handled using `utils.version.is_dist_state_dict_available` function by switching to the previous implementation.
- Add `distributed.factory.simple` API.
- These functions are a simplified implementation of the `state_dict` interfaces in `distributed.factory`.
- Use `simple` in `distributed.DistributedHelper` and `nest.NeST`.
- Add `prepare_stateful` in `distributed.DistributedHelper` and `nest.NeST`.

## Deprecations
- Deprecate `{distributed.DistributedHelper,nest.NeST}.prepare_for_checkpointing` if `torch>=2.2.0`.
  - This is not a deprecation to be exact. The functionality will be kept inside the package until literally no one is using `torch<2.1.x`.
