### PR TITLE
Datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: requirements-txt-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.3.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,7 +5,7 @@ target-version = "py310"
 
 src = ["storch"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["F401", "F403", "F405"]
 
 [lint]

--- a/storch/dataset/__init__.py
+++ b/storch/dataset/__init__.py
@@ -8,5 +8,6 @@ from storch.dataset.dataset import (
     ImagePathFiles,
     _collect_image_paths,
 )
+from storch.dataset.hfdataset import imagecsv, imagefolder, imagepaths, is_datasets_available
 from storch.dataset.transform import make_cutmix_or_mixup, make_simple_transform, make_transform_from_config
 from storch.dataset.utils import is_image_file

--- a/storch/dataset/hfdataset.py
+++ b/storch/dataset/hfdataset.py
@@ -1,0 +1,163 @@
+"""`datasets` dataset."""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Callable
+
+import numpy as np
+
+try:
+    from datasets import Dataset, Image
+except ImportError:
+    Dataset = None
+
+from storch.dataset.utils import is_image_file
+from storch.torchops import local_seed_numpy
+
+
+def is_datasets_available():
+    """Is HuggingFace datasets available."""
+    return Dataset is not None
+
+
+def imagepaths(
+    paths: list[str],
+    transforms: Callable,
+    num_images: int | None = None,
+    filter_fn: Callable | None = None,
+    seed: int | None = None,
+):
+    """Create `dataset.Dataset` object.
+
+    The arguments are made equivalent to `dataset.ImageFolder` class.
+
+    Args:
+    ----
+        paths (list[str]): list of paths to image files.
+        transforms (Callable): A callable that transforms the image.
+        num_images (int | None, optional): If given, the dataset will be reduced to have at most num_images samples.
+            Default: None.
+        filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
+            Default: None.
+        seed (int | None): seed for random sampling when reducing data according to `num_images`. Default: None.
+
+    Returns:
+    -------
+        Dataset: The created dataset.
+
+    """
+    assert is_datasets_available(), 'This function requires the `datasets` module.'
+
+    def generator():
+        for path in paths:
+            if is_image_file(path):
+                yield dict(image=path)
+
+    dataset = Dataset.from_generator(generator)
+    dataset = dataset.sort('image')  # always sort the data.
+
+    if callable(filter_fn):
+        dataset = dataset.filter(filter_fn)
+
+    total_images = len(dataset)
+    if num_images is not None and num_images < total_images:
+        # Reduce dataset size using random permutation.
+        with local_seed_numpy(seed=seed, enabled=seed is not None):
+            permutation = np.random.permutation(total_images)[:num_images]
+        # Sort indices to keep the dataset order.
+        permutation = np.sort(permutation)
+        dataset = dataset.select(permutation)
+
+    dataset = dataset.cast_column('image', Image())
+
+    def transform_sample(sample):
+        sample['image'] = transforms(sample['image'])
+        return sample
+
+    dataset = dataset.with_transform(transform_sample)
+
+    return dataset
+
+
+def imagefolder(
+    data_root: str,
+    transforms: Callable,
+    num_images: int | None = None,
+    filter_fn: Callable | None = None,
+    seed: int | None = None,
+):
+    """Create `dataset.Dataset` object.
+
+    The arguments are made equivalent to `dataset.ImageFolder` class.
+
+    Args:
+    ----
+        data_root (str): Root directory of images. Images are searched recursively inside this folder.
+        transforms (Callable): A callable that transforms the image.
+        num_images (int | None, optional): If given, the dataset will be reduced to have at most num_images samples.
+            Default: None.
+        filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
+            Default: None.
+        seed (int | None): seed for random sampling when reducing data according to `num_images`. Default: None.
+
+    Returns:
+    -------
+        Dataset: The created dataset.
+
+    """
+    return imagepaths(
+        glob.glob(os.path.join(data_root, '**', '*'), recursive=True),
+        transforms=transforms,
+        num_images=num_images,
+        filter_fn=filter_fn,
+        seed=seed,
+    )
+
+
+def imagecsv(
+    csv: str | list[str],
+    transforms: Callable,
+    num_images: int | None = None,
+    filter_fn: Callable | None = None,
+    seed: int | None = None,
+):
+    """Create `dataset.Dataset` object.
+
+    The arguments are made equivalent to `dataset.ImageFolder` class.
+
+    Args:
+    ----
+        csv (str | list[str]): csv file containing the path to image files in each row in the first column. A csv file,
+            multiple csv files in a list, and directory to csv files are supported.
+        transforms (Callable): A callable that transforms the image.
+        num_images (int | None, optional): If given, the dataset will be reduced to have at most num_images samples.
+            Default: None.
+        filter_fn (Callable | None, optional): A callable that inputs a path and returns a bool to filter the files.
+            Default: None.
+        seed (int | None): seed for random sampling when reducing data according to `num_images`. Default: None.
+
+    Returns:
+    -------
+        Dataset: The created dataset.
+
+    """
+
+    def load_csv_first_column(path):
+        with open(path, 'r') as fp:
+            lines = fp.read().strip().splitlines()
+        image_paths = [line.split(',') for line in lines]
+        return image_paths
+
+    if isinstance(csv, str) and os.path.exists(csv):
+        if os.path.isfile(csv):
+            csv = [csv]
+        else:
+            csv = glob.glob(os.path.join(csv, '*.csv'))
+
+    image_paths = []
+    for csv_file in csv:
+        image_paths.extend(load_csv_first_column(csv_file))
+
+    return imagepaths(image_paths, transforms=transforms, num_images=num_images, filter_fn=filter_fn, seed=seed)

--- a/storch/dataset/utils.py
+++ b/storch/dataset/utils.py
@@ -25,7 +25,7 @@ def is_image_file(path: str) -> bool:
         bool: file?
 
     """
-    ext = set(os.path.splitext(os.path.basename(path))[-1].lower())
+    ext = {os.path.splitext(os.path.basename(path))[-1].lower()}
     return ext.issubset(IMG_EXTENSIONS)
 
 

--- a/storch/version.py
+++ b/storch/version.py
@@ -1,2 +1,3 @@
 """Version."""
-__version__ = '0.5.7'
+
+__version__ = '0.5.8'


### PR DESCRIPTION
# WHAT
- Refactor dataset.
- Add 🤗 `datasets` support.

## Changes
- Fix cast in `dataset.utils.is_image_file()`.
- Support `torchvision.transforms.v2` in `dataset.make_simple_transform()`.
- Convert `omegaconf` object to Python objects in `dataset.make_transforms_from_config()`.
- Add `dataset.hfdatasets`.
  - Add `dataset.hfdataset.is_datasets_available()`.
  - Add `dataset.hfdataset.imagepaths()`.
    Creates a `datasets.Dataset` object, given a list of paths to image files.
  - Add `dataset.hfdataset.imagefolder()`.
    Creates a `datasets.Dataset` object, given a directory to image files.
  - Add `dataset.hfdataset.imagecsv()`.
    Creates a `datasets.Dataset` object, given CSV file(s) containing image paths.