### PR TITLE
`bfloat16`

### DIFF
--- a/storch/distributed/factory/simple.py
+++ b/storch/distributed/factory/simple.py
@@ -2,6 +2,7 @@
 
 Some functions are modifications of implementations in the pytorch repo.
 """
+
 from __future__ import annotations
 
 from itertools import chain
@@ -193,7 +194,7 @@ def wrap_module(
         DDP | FSDP | nn.Module: The wrapped module.
 
     """
-    if strategy is None:
+    if strategy in [None, 'none']:
         return module
 
     elif strategy == 'ddp':

--- a/storch/distributed/helper.py
+++ b/storch/distributed/helper.py
@@ -206,7 +206,7 @@ class DistributedHelper:
                 if self.is_primary():
                     print('Data parallelizm default to "ddp".')
 
-            assert mode.lower() in ['ddp', 'fsdp']
+            assert mode.lower() in ['ddp', 'fsdp', 'none']
             self._mode = mode
 
         return self._mode
@@ -312,6 +312,8 @@ class DistributedHelper:
                 wrap_kwargs['mixed_precision'] = mixed_precision
                 if compile and version.is_compiler_available():
                     wrap_kwargs['use_orig_params'] = True
+            elif mode == 'none':
+                factory = NoParallelFactory()
             else:
                 raise Exception(f'Unknown data parallelizm mode "{mode}"')
 

--- a/storch/version.py
+++ b/storch/version.py
@@ -1,3 +1,3 @@
 """Version."""
 
-__version__ = '0.5.11'
+__version__ = '0.5.12'


### PR DESCRIPTION
# WHAT

Fixes #123

## Changes
- Disable GradScaler if AMP dtype is `bfloat16`.