### PR TITLE
🔨 dcp state_dict loading fixed

### DIFF
--- a/storch/utils/version.py
+++ b/storch/utils/version.py
@@ -128,4 +128,4 @@ def is_dist_state_dict_available() -> bool:
         bool: result.
 
     """
-    return is_torch_version_geq('2.2.0')
+    return is_torch_version_geq('2.2.2')

--- a/storch/version.py
+++ b/storch/version.py
@@ -1,3 +1,3 @@
 """Version."""
 
-__version__ = '0.5.12'
+__version__ = '0.5.13'


### PR DESCRIPTION
# WHAT
- DCP api fixed loading buffers on models in `set_model_state_dict`.

## Changes
- Remove self implemented state_dict loading and replace with official impl.
- Change minimal PT version for availability of DCP api.