### PR TITLE
🔨 Backward compatibility with v1 transforms.

### DIFF
--- a/storch/dataset/hfdataset.py
+++ b/storch/dataset/hfdataset.py
@@ -72,9 +72,9 @@ def imagepaths(
 
     dataset = dataset.cast_column('image', Image())
 
-    def transform_sample(sample):
-        sample['image'] = transforms(sample['image'])
-        return sample
+    def transform_sample(samples):
+        samples['image'] = [transforms(image) for image in samples['image']]
+        return samples
 
     dataset = dataset.with_transform(transform_sample)
 

--- a/storch/version.py
+++ b/storch/version.py
@@ -1,3 +1,3 @@
 """Version."""
 
-__version__ = '0.5.14'
+__version__ = '0.5.15'


### PR DESCRIPTION
# WHAT
- Datasets created using huggingface `datasets`, does not support transforms created using v1 torchvision transforms.

## Changes
- Input images to transforms instead of a list of images.
